### PR TITLE
feat(examples): add basic server and client examples

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -2,7 +2,51 @@
 # File Transfer System Examples
 ##################################################
 
-# Examples will be added in subsequent issues
-# See Issue #25 (Example Code Implementation)
+message(STATUS "Building examples")
 
-message(STATUS "Examples directory configured (no examples yet)")
+# Output directory
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin)
+
+##################################################
+# Simple Server Example
+##################################################
+
+add_executable(simple_server
+    simple_server.cpp
+)
+
+target_link_libraries(simple_server
+    PRIVATE
+        kcenon::file_transfer
+)
+
+set_target_properties(simple_server PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+)
+
+##################################################
+# Simple Client Example
+##################################################
+
+add_executable(simple_client
+    simple_client.cpp
+)
+
+target_link_libraries(simple_client
+    PRIVATE
+        kcenon::file_transfer
+)
+
+set_target_properties(simple_client PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+)
+
+##################################################
+# Installation
+##################################################
+
+install(TARGETS simple_server simple_client
+    RUNTIME DESTINATION bin/examples
+)

--- a/examples/simple_client.cpp
+++ b/examples/simple_client.cpp
@@ -1,0 +1,297 @@
+/**
+ * @file simple_client.cpp
+ * @brief Basic file transfer client example
+ *
+ * This example demonstrates how to:
+ * - Create and configure a file transfer client
+ * - Connect to a server
+ * - Upload and download files
+ * - List files on the server
+ * - Handle progress callbacks
+ */
+
+#include <kcenon/file_transfer/client/file_transfer_client.h>
+
+#include <cstring>
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <string>
+
+using namespace kcenon::file_transfer;
+
+void print_usage(const char* program) {
+    std::cout << "Usage: " << program << " <command> [options]" << std::endl;
+    std::cout << std::endl;
+    std::cout << "Commands:" << std::endl;
+    std::cout << "  upload <local_file> <remote_name> [host:port]" << std::endl;
+    std::cout << "  download <remote_name> <local_file> [host:port]" << std::endl;
+    std::cout << "  list [host:port]" << std::endl;
+    std::cout << std::endl;
+    std::cout << "Default server: localhost:8080" << std::endl;
+}
+
+std::pair<std::string, uint16_t> parse_endpoint(const std::string& addr) {
+    auto colon_pos = addr.find(':');
+    if (colon_pos == std::string::npos) {
+        return {addr, 8080};
+    }
+    return {
+        addr.substr(0, colon_pos),
+        static_cast<uint16_t>(std::stoi(addr.substr(colon_pos + 1)))
+    };
+}
+
+void create_test_file(const std::string& path, size_t size) {
+    std::ofstream file(path, std::ios::binary);
+    std::vector<char> data(size);
+    for (size_t i = 0; i < size; ++i) {
+        data[i] = static_cast<char>('A' + (i % 26));
+    }
+    file.write(data.data(), static_cast<std::streamsize>(data.size()));
+    std::cout << "Created test file: " << path << " (" << size << " bytes)" << std::endl;
+}
+
+int main(int argc, char* argv[]) {
+    if (argc < 2) {
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    std::string command = argv[1];
+
+    // Build client with configuration
+    auto client_result = file_transfer_client::builder()
+        .with_compression(compression_mode::adaptive)
+        .with_compression_level(compression_level::fast)
+        .with_auto_reconnect(true)
+        .with_connect_timeout(std::chrono::milliseconds{5000})
+        .build();
+
+    if (!client_result.has_value()) {
+        std::cerr << "Failed to create client: "
+                  << client_result.error().message << std::endl;
+        return 1;
+    }
+
+    auto& client = client_result.value();
+
+    // Register progress callback
+    client.on_progress([](const transfer_progress& progress) {
+        std::cout << "\r[Progress] " << progress.filename
+                  << ": " << static_cast<int>(progress.percentage) << "%"
+                  << " (" << progress.bytes_transferred << "/" << progress.total_bytes << " bytes)"
+                  << std::flush;
+        if (progress.percentage >= 100.0) {
+            std::cout << std::endl;
+        }
+    });
+
+    // Register completion callback
+    client.on_complete([](const transfer_result& result) {
+        if (result.success) {
+            std::cout << "[Complete] " << result.filename
+                      << " - " << result.bytes_transferred << " bytes transferred"
+                      << std::endl;
+        } else {
+            std::cout << "[Failed] " << result.filename
+                      << " - " << result.error_message << std::endl;
+        }
+    });
+
+    // Register connection state callback
+    client.on_connection_state_changed([](connection_state state) {
+        std::cout << "[Connection] State changed to: " << to_string(state) << std::endl;
+    });
+
+    // Parse server address
+    std::string host = "localhost";
+    uint16_t port = 8080;
+
+    // Handle commands
+    if (command == "upload") {
+        if (argc < 4) {
+            std::cerr << "Usage: " << argv[0] << " upload <local_file> <remote_name> [host:port]"
+                      << std::endl;
+            return 1;
+        }
+
+        std::string local_path = argv[2];
+        std::string remote_name = argv[3];
+        if (argc >= 5) {
+            std::tie(host, port) = parse_endpoint(argv[4]);
+        }
+
+        // Check if file exists, create test file if it doesn't
+        if (!std::filesystem::exists(local_path)) {
+            std::cout << "File not found, creating test file..." << std::endl;
+            create_test_file(local_path, 1024 * 1024);  // 1MB test file
+        }
+
+        std::cout << "=== File Upload ===" << std::endl;
+        std::cout << "Server: " << host << ":" << port << std::endl;
+        std::cout << "Local: " << local_path << std::endl;
+        std::cout << "Remote: " << remote_name << std::endl;
+        std::cout << std::endl;
+
+        // Connect to server
+        std::cout << "Connecting to server..." << std::endl;
+        auto connect_result = client.connect(endpoint{host, port});
+        if (!connect_result.has_value()) {
+            std::cerr << "Failed to connect: " << connect_result.error().message << std::endl;
+            return 1;
+        }
+        std::cout << "Connected!" << std::endl;
+
+        // Upload file
+        std::cout << "Starting upload..." << std::endl;
+        auto upload_result = client.upload_file(local_path, remote_name);
+        if (!upload_result.has_value()) {
+            std::cerr << "Upload failed: " << upload_result.error().message << std::endl;
+            (void)client.disconnect();
+            return 1;
+        }
+
+        std::cout << "Upload initiated with handle: " << upload_result.value().id << std::endl;
+
+        // Disconnect
+        auto disconnect_result = client.disconnect();
+        if (!disconnect_result.has_value()) {
+            std::cerr << "Disconnect error: " << disconnect_result.error().message << std::endl;
+        }
+
+    } else if (command == "download") {
+        if (argc < 4) {
+            std::cerr << "Usage: " << argv[0] << " download <remote_name> <local_file> [host:port]"
+                      << std::endl;
+            return 1;
+        }
+
+        std::string remote_name = argv[2];
+        std::string local_path = argv[3];
+        if (argc >= 5) {
+            std::tie(host, port) = parse_endpoint(argv[4]);
+        }
+
+        std::cout << "=== File Download ===" << std::endl;
+        std::cout << "Server: " << host << ":" << port << std::endl;
+        std::cout << "Remote: " << remote_name << std::endl;
+        std::cout << "Local: " << local_path << std::endl;
+        std::cout << std::endl;
+
+        // Connect to server
+        std::cout << "Connecting to server..." << std::endl;
+        auto connect_result = client.connect(endpoint{host, port});
+        if (!connect_result.has_value()) {
+            std::cerr << "Failed to connect: " << connect_result.error().message << std::endl;
+            return 1;
+        }
+        std::cout << "Connected!" << std::endl;
+
+        // Download file
+        std::cout << "Starting download..." << std::endl;
+        download_options options;
+        options.overwrite = true;
+        options.verify_hash = true;
+
+        auto download_result = client.download_file(remote_name, local_path, options);
+        if (!download_result.has_value()) {
+            std::cerr << "Download failed: " << download_result.error().message << std::endl;
+            (void)client.disconnect();
+            return 1;
+        }
+
+        std::cout << "Download initiated with handle: " << download_result.value().id << std::endl;
+
+        // Disconnect
+        auto disconnect_result = client.disconnect();
+        if (!disconnect_result.has_value()) {
+            std::cerr << "Disconnect error: " << disconnect_result.error().message << std::endl;
+        }
+
+    } else if (command == "list") {
+        if (argc >= 3) {
+            std::tie(host, port) = parse_endpoint(argv[2]);
+        }
+
+        std::cout << "=== List Files ===" << std::endl;
+        std::cout << "Server: " << host << ":" << port << std::endl;
+        std::cout << std::endl;
+
+        // Connect to server
+        std::cout << "Connecting to server..." << std::endl;
+        auto connect_result = client.connect(endpoint{host, port});
+        if (!connect_result.has_value()) {
+            std::cerr << "Failed to connect: " << connect_result.error().message << std::endl;
+            return 1;
+        }
+        std::cout << "Connected!" << std::endl;
+
+        // List files
+        std::cout << "Fetching file list..." << std::endl;
+        list_options options;
+        options.pattern = "*";
+        options.limit = 100;
+
+        auto list_result = client.list_files(options);
+        if (!list_result.has_value()) {
+            std::cerr << "List failed: " << list_result.error().message << std::endl;
+            (void)client.disconnect();
+            return 1;
+        }
+
+        auto& files = list_result.value();
+        std::cout << std::endl;
+        std::cout << "Files on server (" << files.size() << "):" << std::endl;
+        std::cout << std::string(60, '-') << std::endl;
+        std::cout << "Name                                    Size        Hash" << std::endl;
+        std::cout << std::string(60, '-') << std::endl;
+
+        for (const auto& file : files) {
+            std::cout << file.filename;
+            if (file.filename.length() < 40) {
+                std::cout << std::string(40 - file.filename.length(), ' ');
+            }
+            std::cout << file.size << " bytes  ";
+            if (file.sha256_hash.length() > 16) {
+                std::cout << file.sha256_hash.substr(0, 16) << "...";
+            } else {
+                std::cout << file.sha256_hash;
+            }
+            std::cout << std::endl;
+        }
+
+        if (files.empty()) {
+            std::cout << "(No files)" << std::endl;
+        }
+        std::cout << std::string(60, '-') << std::endl;
+
+        // Disconnect
+        auto disconnect_result = client.disconnect();
+        if (!disconnect_result.has_value()) {
+            std::cerr << "Disconnect error: " << disconnect_result.error().message << std::endl;
+        }
+
+    } else {
+        std::cerr << "Unknown command: " << command << std::endl;
+        print_usage(argv[0]);
+        return 1;
+    }
+
+    // Print final statistics
+    auto stats = client.get_statistics();
+    auto compression = client.get_compression_stats();
+
+    std::cout << std::endl;
+    std::cout << "=== Statistics ===" << std::endl;
+    std::cout << "Bytes uploaded: " << stats.total_bytes_uploaded << std::endl;
+    std::cout << "Bytes downloaded: " << stats.total_bytes_downloaded << std::endl;
+    std::cout << "Files uploaded: " << stats.total_files_uploaded << std::endl;
+    std::cout << "Files downloaded: " << stats.total_files_downloaded << std::endl;
+    std::cout << "Compression ratio: " << compression.compression_ratio() << std::endl;
+
+    std::cout << std::endl;
+    std::cout << "Done." << std::endl;
+
+    return 0;
+}

--- a/examples/simple_server.cpp
+++ b/examples/simple_server.cpp
@@ -1,0 +1,158 @@
+/**
+ * @file simple_server.cpp
+ * @brief Basic file transfer server example
+ *
+ * This example demonstrates how to:
+ * - Create and configure a file transfer server
+ * - Register event callbacks
+ * - Start the server and handle connections
+ * - Gracefully shut down the server
+ */
+
+#include <kcenon/file_transfer/server/file_transfer_server.h>
+
+#include <csignal>
+#include <iostream>
+#include <string>
+#include <thread>
+
+using namespace kcenon::file_transfer;
+
+// Global flag for graceful shutdown
+static std::atomic<bool> running{true};
+
+void signal_handler(int signal) {
+    if (signal == SIGINT || signal == SIGTERM) {
+        std::cout << "\nShutdown signal received..." << std::endl;
+        running = false;
+    }
+}
+
+int main(int argc, char* argv[]) {
+    // Parse command line arguments
+    uint16_t port = 8080;
+    std::string storage_dir = "./server_storage";
+
+    if (argc >= 2) {
+        port = static_cast<uint16_t>(std::stoi(argv[1]));
+    }
+    if (argc >= 3) {
+        storage_dir = argv[2];
+    }
+
+    std::cout << "=== File Transfer Server Example ===" << std::endl;
+    std::cout << "Port: " << port << std::endl;
+    std::cout << "Storage: " << storage_dir << std::endl;
+    std::cout << std::endl;
+
+    // Build server with configuration
+    auto server_result = file_transfer_server::builder()
+        .with_storage_directory(storage_dir)
+        .with_max_connections(100)
+        .with_max_file_size(10ULL * 1024 * 1024 * 1024)  // 10GB
+        .with_storage_quota(100ULL * 1024 * 1024 * 1024)  // 100GB
+        .with_chunk_size(256 * 1024)  // 256KB
+        .build();
+
+    if (!server_result.has_value()) {
+        std::cerr << "Failed to create server: "
+                  << server_result.error().message << std::endl;
+        return 1;
+    }
+
+    auto& server = server_result.value();
+
+    // Register callbacks
+    server.on_client_connected([](const client_info& info) {
+        std::cout << "[Connected] Client " << info.id.value
+                  << " from " << info.address << ":" << info.port << std::endl;
+    });
+
+    server.on_client_disconnected([](const client_info& info) {
+        std::cout << "[Disconnected] Client " << info.id.value << std::endl;
+    });
+
+    server.on_upload_request([](const upload_request& req) {
+        std::cout << "[Upload Request] File: " << req.filename
+                  << ", Size: " << req.file_size << " bytes" << std::endl;
+        return true;  // Accept the upload
+    });
+
+    server.on_download_request([](const download_request& req) {
+        std::cout << "[Download Request] File: " << req.filename << std::endl;
+        return true;  // Accept the download
+    });
+
+    server.on_transfer_complete([](const transfer_result& result) {
+        if (result.success) {
+            std::cout << "[Transfer Complete] File: " << result.filename
+                      << ", Bytes: " << result.bytes_transferred << std::endl;
+        } else {
+            std::cout << "[Transfer Failed] File: " << result.filename
+                      << ", Error: " << result.error_message << std::endl;
+        }
+    });
+
+    server.on_progress([](const transfer_progress& progress) {
+        std::cout << "\r[Progress] " << progress.filename
+                  << ": " << static_cast<int>(progress.percentage) << "%"
+                  << std::flush;
+        if (progress.percentage >= 100.0) {
+            std::cout << std::endl;
+        }
+    });
+
+    // Start the server
+    auto start_result = server.start(endpoint{port});
+    if (!start_result.has_value()) {
+        std::cerr << "Failed to start server: "
+                  << start_result.error().message << std::endl;
+        return 1;
+    }
+
+    std::cout << "Server started on port " << port << std::endl;
+    std::cout << "Press Ctrl+C to stop..." << std::endl;
+    std::cout << std::endl;
+
+    // Set up signal handlers for graceful shutdown
+    std::signal(SIGINT, signal_handler);
+    std::signal(SIGTERM, signal_handler);
+
+    // Main loop - wait for shutdown signal
+    while (running && server.is_running()) {
+        // Print statistics periodically
+        auto stats = server.get_statistics();
+        auto storage = server.get_storage_stats();
+
+        std::cout << "\r[Stats] Connections: " << stats.active_connections
+                  << " | Transfers: " << stats.active_transfers
+                  << " | Files: " << storage.file_count
+                  << " | Storage: " << (storage.used_size / (1024 * 1024)) << "MB"
+                  << std::flush;
+
+        std::this_thread::sleep_for(std::chrono::seconds(5));
+    }
+
+    std::cout << std::endl;
+
+    // Graceful shutdown
+    std::cout << "Stopping server..." << std::endl;
+    auto stop_result = server.stop();
+    if (!stop_result.has_value()) {
+        std::cerr << "Error during shutdown: "
+                  << stop_result.error().message << std::endl;
+    }
+
+    std::cout << "Server stopped." << std::endl;
+
+    // Print final statistics
+    auto final_stats = server.get_statistics();
+    std::cout << std::endl;
+    std::cout << "=== Final Statistics ===" << std::endl;
+    std::cout << "Total bytes received: " << final_stats.total_bytes_received << std::endl;
+    std::cout << "Total bytes sent: " << final_stats.total_bytes_sent << std::endl;
+    std::cout << "Total files uploaded: " << final_stats.total_files_uploaded << std::endl;
+    std::cout << "Total files downloaded: " << final_stats.total_files_downloaded << std::endl;
+
+    return 0;
+}


### PR DESCRIPTION
## Summary
- Add `simple_server.cpp` demonstrating server setup, callback registration, and graceful shutdown
- Add `simple_client.cpp` demonstrating file upload, download, and listing operations
- Update `examples/CMakeLists.txt` to build both examples

## Test plan
- [x] Build with `cmake -DFILE_TRANS_BUILD_EXAMPLES=ON`
- [x] Verify examples compile without warnings
- [x] Verify all existing tests pass (291 unit tests, 77 integration tests)

Closes #37