### PR TITLE
feat(benchmarks): Implement benchmark framework and throughput benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,33 @@ UBSAN_OPTIONS="print_stacktrace=1:abort_on_error=1" ctest --test-dir build
 
 > **Note**: ASAN and TSAN cannot be enabled simultaneously.
 
+### Benchmarks
+
+Build and run performance benchmarks:
+
+```bash
+# Build with benchmarks enabled
+cmake -B build -DFILE_TRANS_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+
+# Run throughput benchmarks
+./build/bin/throughput_benchmarks
+
+# Run with JSON output
+./build/bin/throughput_benchmarks --benchmark_format=json --benchmark_out=results.json
+
+# Run specific benchmarks
+./build/bin/throughput_benchmarks --benchmark_filter="BM_SingleFile*"
+```
+
+#### Benchmark Categories
+
+| Category | Description | Target |
+|----------|-------------|--------|
+| **Throughput** | File split/assembly throughput | ≥ 500 MB/s |
+| **Chunk Operations** | Chunk splitter and assembler performance | - |
+| **Checksum** | CRC32 and SHA-256 performance | - |
+
 ### CMake Integration
 
 ```cmake

--- a/README_KR.md
+++ b/README_KR.md
@@ -360,6 +360,33 @@ UBSAN_OPTIONS="print_stacktrace=1:abort_on_error=1" ctest --test-dir build
 
 > **참고**: ASAN과 TSAN은 동시에 활성화할 수 없습니다.
 
+### 벤치마크
+
+성능 벤치마크를 빌드하고 실행합니다:
+
+```bash
+# 벤치마크 활성화로 빌드
+cmake -B build -DFILE_TRANS_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+
+# 처리량 벤치마크 실행
+./build/bin/throughput_benchmarks
+
+# JSON 출력으로 실행
+./build/bin/throughput_benchmarks --benchmark_format=json --benchmark_out=results.json
+
+# 특정 벤치마크 실행
+./build/bin/throughput_benchmarks --benchmark_filter="BM_SingleFile*"
+```
+
+#### 벤치마크 카테고리
+
+| 카테고리 | 설명 | 목표 |
+|---------|-----|-----|
+| **Throughput** | 파일 분할/조립 처리량 | ≥ 500 MB/s |
+| **Chunk Operations** | 청크 스플리터 및 어셈블러 성능 | - |
+| **Checksum** | CRC32 및 SHA-256 성능 | - |
+
 ### CMake 통합
 
 ```cmake

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -1,8 +1,121 @@
 ##################################################
-# File Transfer System Benchmarks
+# File Transfer System Benchmarks Configuration
 ##################################################
 
-# Benchmarks will be added in subsequent issues
-# See Issue #24 (Performance Benchmark Implementation)
+##################################################
+# Google Benchmark Configuration via FetchContent
+##################################################
 
-message(STATUS "Benchmarks directory configured (no benchmarks yet)")
+include(FetchContent)
+
+# Declare Google Benchmark dependency
+FetchContent_Declare(
+    googlebenchmark
+    GIT_REPOSITORY https://github.com/google/benchmark.git
+    GIT_TAG v1.8.3
+    GIT_SHALLOW TRUE
+)
+
+# Disable testing in Google Benchmark
+set(BENCHMARK_ENABLE_TESTING OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_INSTALL OFF CACHE BOOL "" FORCE)
+set(BENCHMARK_ENABLE_GTEST_TESTS OFF CACHE BOOL "" FORCE)
+
+# Make available
+FetchContent_MakeAvailable(googlebenchmark)
+
+message(STATUS "Google Benchmark configured via FetchContent")
+
+##################################################
+# Benchmark Utilities Library
+##################################################
+
+add_library(benchmark_utils STATIC
+    utils/benchmark_helpers.cpp
+)
+
+target_include_directories(benchmark_utils
+    PUBLIC
+        ${CMAKE_CURRENT_SOURCE_DIR}
+)
+
+target_link_libraries(benchmark_utils
+    PUBLIC
+        FileTransSystem
+        benchmark::benchmark
+)
+
+set_target_properties(benchmark_utils PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+)
+
+##################################################
+# Throughput Benchmarks
+##################################################
+
+add_executable(throughput_benchmarks
+    throughput/bench_single_file_throughput.cpp
+    throughput/bench_chunk_operations.cpp
+)
+
+target_link_libraries(throughput_benchmarks PRIVATE
+    FileTransSystem
+    benchmark_utils
+    benchmark::benchmark
+    benchmark::benchmark_main
+    Threads::Threads
+)
+
+set_target_properties(throughput_benchmarks PROPERTIES
+    CXX_STANDARD 20
+    CXX_STANDARD_REQUIRED ON
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+)
+
+##################################################
+# Compression Benchmarks (Future)
+##################################################
+
+# add_executable(compression_benchmarks
+#     compression/bench_lz4_compression.cpp
+# )
+
+##################################################
+# Memory Benchmarks (Future)
+##################################################
+
+# add_executable(memory_benchmarks
+#     memory/bench_memory_usage.cpp
+# )
+
+##################################################
+# Benchmark Data Setup
+##################################################
+
+# Create benchmark data directory
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/bin/benchmark_data)
+
+##################################################
+# Custom Targets for Running Benchmarks
+##################################################
+
+add_custom_target(run_throughput_benchmarks
+    COMMAND $<TARGET_FILE:throughput_benchmarks>
+        --benchmark_format=console
+        --benchmark_out=${CMAKE_BINARY_DIR}/benchmark_results/throughput.json
+        --benchmark_out_format=json
+    DEPENDS throughput_benchmarks
+    WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/bin
+    COMMENT "Running throughput benchmarks..."
+)
+
+add_custom_target(run_benchmarks
+    DEPENDS run_throughput_benchmarks
+    COMMENT "Running all benchmarks..."
+)
+
+# Create results directory
+file(MAKE_DIRECTORY ${CMAKE_BINARY_DIR}/benchmark_results)
+
+message(STATUS "Benchmarks configured")

--- a/benchmarks/README.md
+++ b/benchmarks/README.md
@@ -1,0 +1,165 @@
+# file_trans_system Benchmarks
+
+Performance benchmarks for the file_trans_system library, built with [Google Benchmark](https://github.com/google/benchmark).
+
+## Building
+
+Benchmarks are disabled by default. Enable them with:
+
+```bash
+cmake -B build -DFILE_TRANS_BUILD_BENCHMARKS=ON -DCMAKE_BUILD_TYPE=Release
+cmake --build build --parallel
+```
+
+## Running Benchmarks
+
+### Basic Usage
+
+```bash
+# Run all throughput benchmarks
+./build/bin/throughput_benchmarks
+
+# Run with detailed output
+./build/bin/throughput_benchmarks --benchmark_counters_tabular=true
+```
+
+### Output Formats
+
+```bash
+# JSON output (for analysis)
+./build/bin/throughput_benchmarks --benchmark_format=json --benchmark_out=results.json
+
+# CSV output
+./build/bin/throughput_benchmarks --benchmark_format=csv --benchmark_out=results.csv
+
+# Console with JSON file
+./build/bin/throughput_benchmarks --benchmark_out=results.json --benchmark_out_format=json
+```
+
+### Filtering Benchmarks
+
+```bash
+# Run only split throughput benchmarks
+./build/bin/throughput_benchmarks --benchmark_filter="BM_SingleFile_Split*"
+
+# Run only CRC32 benchmarks
+./build/bin/throughput_benchmarks --benchmark_filter="BM_Checksum_CRC32*"
+
+# Run all chunk operations
+./build/bin/throughput_benchmarks --benchmark_filter="BM_Chunk*"
+```
+
+### Controlling Iterations
+
+```bash
+# Run each benchmark for at least 5 seconds
+./build/bin/throughput_benchmarks --benchmark_min_time=5
+
+# Run exactly 100 iterations
+./build/bin/throughput_benchmarks --benchmark_repetitions=100
+```
+
+## Benchmark Categories
+
+### Throughput Benchmarks (`throughput/`)
+
+| Benchmark | Description | Parameters |
+|-----------|-------------|------------|
+| `BM_SingleFile_SplitThroughput` | File splitting throughput | File size: 100KB - 100MB |
+| `BM_SingleFile_AssemblyThroughput` | Chunk assembly throughput | File size: 100KB - 100MB |
+| `BM_SingleFile_RoundTripThroughput` | Complete split + assembly cycle | File size: 100KB - 100MB |
+| `BM_SingleFile_ChunkSizeImpact` | Chunk size effect on throughput | Chunk: 64KB - 1MB |
+
+### Chunk Operation Benchmarks
+
+| Benchmark | Description | Parameters |
+|-----------|-------------|------------|
+| `BM_ChunkSplitter_Split` | Chunk splitting performance | File/chunk size combinations |
+| `BM_ChunkAssembler_Process` | Chunk processing performance | File/chunk size combinations |
+
+### Checksum Benchmarks
+
+| Benchmark | Description | Parameters |
+|-----------|-------------|------------|
+| `BM_Checksum_CRC32` | CRC32 calculation speed | Data size: 1KB - 1MB |
+| `BM_Checksum_SHA256` | SHA-256 calculation speed | Data size: 1KB - 1MB |
+| `BM_Checksum_SHA256_File` | File hash calculation | File size: 100KB - 100MB |
+
+## Performance Targets
+
+Based on SRS requirements:
+
+| Metric | Target | Benchmark |
+|--------|--------|-----------|
+| LAN Throughput | >= 500 MB/s | `BM_SingleFile_*Throughput` |
+| LZ4 Compression | >= 400 MB/s | (Future: compression benchmarks) |
+| LZ4 Decompression | >= 1.5 GB/s | (Future: compression benchmarks) |
+| Server Memory | < 100 MB | (Future: memory benchmarks) |
+| Client Memory | < 50 MB | (Future: memory benchmarks) |
+
+## Directory Structure
+
+```
+benchmarks/
+├── CMakeLists.txt           # Benchmark build configuration
+├── README.md                # This file
+├── utils/
+│   ├── benchmark_helpers.h  # Test data generation utilities
+│   └── benchmark_helpers.cpp
+└── throughput/
+    ├── bench_single_file_throughput.cpp  # End-to-end throughput
+    └── bench_chunk_operations.cpp        # Component benchmarks
+```
+
+## Adding New Benchmarks
+
+1. Create a new `.cpp` file in the appropriate directory
+2. Include required headers:
+   ```cpp
+   #include <benchmark/benchmark.h>
+   #include "utils/benchmark_helpers.h"
+   ```
+3. Write benchmark functions:
+   ```cpp
+   static void BM_MyBenchmark(::benchmark::State& state) {
+       for (auto _ : state) {
+           // Code to benchmark
+       }
+       state.SetBytesProcessed(...);
+   }
+   BENCHMARK(BM_MyBenchmark)->Arg(1024)->Arg(1024*1024);
+   ```
+4. Add the file to `CMakeLists.txt`
+
+## Interpreting Results
+
+### Key Metrics
+
+- **Time**: Wall clock time per iteration
+- **CPU**: CPU time per iteration
+- **bytes_per_second**: Throughput in bytes/second
+- **items_per_second**: Operations per second
+- **throughput_MB_s**: Custom counter for MB/s throughput
+
+### Example Output
+
+```
+-----------------------------------------------------------------------
+Benchmark                             Time             CPU   Iterations
+-----------------------------------------------------------------------
+BM_SingleFile_SplitThroughput/100MB  195 ms         195 ms         10
+BM_Checksum_CRC32/1024               2.5 us         2.5 us     280000
+```
+
+## CI Integration
+
+Benchmarks can be run in CI with:
+
+```bash
+./build/bin/throughput_benchmarks \
+    --benchmark_format=json \
+    --benchmark_out=benchmark_results.json \
+    --benchmark_repetitions=3
+```
+
+Use the JSON output for regression detection by comparing against baseline results.

--- a/benchmarks/throughput/bench_chunk_operations.cpp
+++ b/benchmarks/throughput/bench_chunk_operations.cpp
@@ -1,0 +1,231 @@
+/**
+ * @file bench_chunk_operations.cpp
+ * @brief Benchmarks for chunk splitting and assembling operations
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <kcenon/file_transfer/core/chunk_assembler.h>
+#include <kcenon/file_transfer/core/chunk_splitter.h>
+#include <kcenon/file_transfer/core/checksum.h>
+
+#include "utils/benchmark_helpers.h"
+
+#include <filesystem>
+#include <fstream>
+#include <memory>
+
+namespace kcenon::file_transfer::benchmark {
+
+/**
+ * @brief Benchmark for chunk_splitter with various file sizes
+ */
+static void BM_ChunkSplitter_Split(::benchmark::State& state) {
+    const auto file_size = static_cast<std::size_t>(state.range(0));
+    const auto chunk_size = static_cast<std::size_t>(state.range(1));
+
+    temp_file_manager temp_files;
+    auto test_file = temp_files.create_random_file("split_test.bin", file_size, 42);
+
+    chunk_config config(chunk_size);
+    chunk_splitter splitter(config);
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto id = transfer_id::generate();
+        state.ResumeTiming();
+
+        auto result = splitter.split(test_file, id);
+        if (!result) {
+            state.SkipWithError("Failed to create splitter iterator");
+            return;
+        }
+
+        auto& iterator = result.value();
+        while (iterator.has_next()) {
+            auto chunk_result = iterator.next();
+            if (!chunk_result) {
+                state.SkipWithError("Failed to get chunk");
+                return;
+            }
+            ::benchmark::DoNotOptimize(chunk_result.value());
+        }
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(file_size) *
+                           static_cast<int64_t>(state.iterations()));
+    state.SetItemsProcessed(static_cast<int64_t>((file_size + chunk_size - 1) / chunk_size) *
+                           static_cast<int64_t>(state.iterations()));
+}
+
+/**
+ * @brief Benchmark for chunk_assembler processing
+ */
+static void BM_ChunkAssembler_Process(::benchmark::State& state) {
+    const auto file_size = static_cast<std::size_t>(state.range(0));
+    const auto chunk_size = static_cast<std::size_t>(state.range(1));
+
+    temp_file_manager temp_files;
+    auto test_file = temp_files.create_random_file("assemble_source.bin", file_size, 42);
+
+    // Pre-generate all chunks
+    chunk_config config(chunk_size);
+    chunk_splitter splitter(config);
+    std::vector<chunk> chunks;
+
+    auto id = transfer_id::generate();
+    auto split_result = splitter.split(test_file, id);
+    if (!split_result) {
+        state.SkipWithError("Failed to create splitter");
+        return;
+    }
+
+    auto& iterator = split_result.value();
+    while (iterator.has_next()) {
+        auto chunk_result = iterator.next();
+        if (chunk_result) {
+            chunks.push_back(std::move(chunk_result.value()));
+        }
+    }
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto output_dir = std::filesystem::temp_directory_path() / "bench_assembler_output";
+        std::filesystem::create_directories(output_dir);
+        chunk_assembler assembler(output_dir);
+
+        auto new_id = transfer_id::generate();
+        // Update chunk IDs for new session
+        std::vector<chunk> session_chunks;
+        session_chunks.reserve(chunks.size());
+        for (const auto& c : chunks) {
+            chunk new_chunk = c;
+            new_chunk.header.id = new_id;
+            session_chunks.push_back(std::move(new_chunk));
+        }
+
+        auto start_result = assembler.start_session(
+            new_id, "output.bin", file_size, chunks.size());
+        if (!start_result) {
+            state.SkipWithError("Failed to start session");
+            std::filesystem::remove_all(output_dir);
+            return;
+        }
+        state.ResumeTiming();
+
+        for (auto& chunk : session_chunks) {
+            auto process_result = assembler.process_chunk(chunk);
+            if (!process_result) {
+                state.SkipWithError("Failed to process chunk");
+                break;
+            }
+        }
+
+        state.PauseTiming();
+        assembler.cancel_session(new_id);
+        std::filesystem::remove_all(output_dir);
+        state.ResumeTiming();
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(file_size) *
+                           static_cast<int64_t>(state.iterations()));
+    state.SetItemsProcessed(static_cast<int64_t>(chunks.size()) *
+                           static_cast<int64_t>(state.iterations()));
+}
+
+/**
+ * @brief Benchmark for CRC32 checksum calculation
+ */
+static void BM_Checksum_CRC32(::benchmark::State& state) {
+    const auto data_size = static_cast<std::size_t>(state.range(0));
+    auto data = test_data_generator::generate_random_data(data_size, 42);
+
+    for (auto _ : state) {
+        auto crc = checksum::crc32(data);
+        ::benchmark::DoNotOptimize(crc);
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(data_size) *
+                           static_cast<int64_t>(state.iterations()));
+}
+
+/**
+ * @brief Benchmark for SHA-256 hash calculation
+ */
+static void BM_Checksum_SHA256(::benchmark::State& state) {
+    const auto data_size = static_cast<std::size_t>(state.range(0));
+    auto data = test_data_generator::generate_random_data(data_size, 42);
+
+    for (auto _ : state) {
+        auto hash = checksum::sha256(data);
+        ::benchmark::DoNotOptimize(hash);
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(data_size) *
+                           static_cast<int64_t>(state.iterations()));
+}
+
+/**
+ * @brief Benchmark for SHA-256 file hash calculation
+ */
+static void BM_Checksum_SHA256_File(::benchmark::State& state) {
+    const auto file_size = static_cast<std::size_t>(state.range(0));
+
+    temp_file_manager temp_files;
+    auto test_file = temp_files.create_random_file("sha256_test.bin", file_size, 42);
+
+    for (auto _ : state) {
+        auto result = checksum::sha256_file(test_file);
+        if (!result) {
+            state.SkipWithError("Failed to calculate file hash");
+            return;
+        }
+        ::benchmark::DoNotOptimize(result.value());
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(file_size) *
+                           static_cast<int64_t>(state.iterations()));
+}
+
+// Register benchmarks with various sizes
+
+// Chunk Splitter benchmarks
+BENCHMARK(BM_ChunkSplitter_Split)
+    ->Args({static_cast<int64_t>(sizes::small_file), static_cast<int64_t>(sizes::default_chunk)})
+    ->Args({static_cast<int64_t>(sizes::medium_file), static_cast<int64_t>(sizes::default_chunk)})
+    ->Args({static_cast<int64_t>(sizes::large_file), static_cast<int64_t>(sizes::default_chunk)})
+    ->Args({static_cast<int64_t>(sizes::large_file), static_cast<int64_t>(sizes::min_chunk)})
+    ->Args({static_cast<int64_t>(sizes::large_file), static_cast<int64_t>(sizes::max_chunk)})
+    ->Unit(::benchmark::kMillisecond);
+
+// Chunk Assembler benchmarks
+BENCHMARK(BM_ChunkAssembler_Process)
+    ->Args({static_cast<int64_t>(sizes::small_file), static_cast<int64_t>(sizes::default_chunk)})
+    ->Args({static_cast<int64_t>(sizes::medium_file), static_cast<int64_t>(sizes::default_chunk)})
+    ->Args({static_cast<int64_t>(sizes::large_file), static_cast<int64_t>(sizes::default_chunk)})
+    ->Unit(::benchmark::kMillisecond);
+
+// CRC32 benchmarks
+BENCHMARK(BM_Checksum_CRC32)
+    ->Arg(static_cast<int64_t>(1 * sizes::KB))
+    ->Arg(static_cast<int64_t>(64 * sizes::KB))
+    ->Arg(static_cast<int64_t>(256 * sizes::KB))
+    ->Arg(static_cast<int64_t>(1 * sizes::MB))
+    ->Unit(::benchmark::kMicrosecond);
+
+// SHA-256 benchmarks
+BENCHMARK(BM_Checksum_SHA256)
+    ->Arg(static_cast<int64_t>(1 * sizes::KB))
+    ->Arg(static_cast<int64_t>(64 * sizes::KB))
+    ->Arg(static_cast<int64_t>(256 * sizes::KB))
+    ->Arg(static_cast<int64_t>(1 * sizes::MB))
+    ->Unit(::benchmark::kMicrosecond);
+
+// SHA-256 File benchmarks
+BENCHMARK(BM_Checksum_SHA256_File)
+    ->Arg(static_cast<int64_t>(sizes::small_file))
+    ->Arg(static_cast<int64_t>(sizes::medium_file))
+    ->Arg(static_cast<int64_t>(sizes::large_file))
+    ->Unit(::benchmark::kMillisecond);
+
+}  // namespace kcenon::file_transfer::benchmark

--- a/benchmarks/throughput/bench_single_file_throughput.cpp
+++ b/benchmarks/throughput/bench_single_file_throughput.cpp
@@ -1,0 +1,316 @@
+/**
+ * @file bench_single_file_throughput.cpp
+ * @brief Benchmarks for single file transfer throughput
+ *
+ * Measures end-to-end throughput for file splitting and assembly operations,
+ * targeting >= 500 MB/s for LAN transfers.
+ */
+
+#include <benchmark/benchmark.h>
+
+#include <kcenon/file_transfer/core/chunk_assembler.h>
+#include <kcenon/file_transfer/core/chunk_splitter.h>
+
+#include "utils/benchmark_helpers.h"
+
+#include <filesystem>
+#include <fstream>
+#include <iostream>
+#include <memory>
+
+namespace kcenon::file_transfer::benchmark {
+
+/**
+ * @brief Benchmark for complete file splitting throughput
+ *
+ * Measures throughput of splitting files into chunks, including:
+ * - File I/O
+ * - CRC32 calculation per chunk
+ * - Memory operations
+ */
+static void BM_SingleFile_SplitThroughput(::benchmark::State& state) {
+    const auto file_size = static_cast<std::size_t>(state.range(0));
+
+    temp_file_manager temp_files;
+    auto test_file = temp_files.create_random_file("throughput_test.bin", file_size, 42);
+
+    chunk_config config(sizes::default_chunk);
+    chunk_splitter splitter(config);
+
+    uint64_t total_chunks = 0;
+
+    for (auto _ : state) {
+        auto id = transfer_id::generate();
+        auto result = splitter.split(test_file, id);
+
+        if (!result) {
+            state.SkipWithError("Failed to create splitter iterator");
+            return;
+        }
+
+        auto& iterator = result.value();
+        uint64_t chunks_processed = 0;
+
+        while (iterator.has_next()) {
+            auto chunk_result = iterator.next();
+            if (!chunk_result) {
+                state.SkipWithError("Failed to get chunk");
+                return;
+            }
+            ++chunks_processed;
+            ::benchmark::DoNotOptimize(chunk_result.value());
+        }
+
+        total_chunks = chunks_processed;
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(file_size) *
+                           static_cast<int64_t>(state.iterations()));
+    state.counters["chunks"] = static_cast<double>(total_chunks);
+    state.counters["throughput_MB_s"] =
+        ::benchmark::Counter(static_cast<double>(file_size) / sizes::MB,
+                            ::benchmark::Counter::kIsIterationInvariantRate);
+}
+
+/**
+ * @brief Benchmark for complete file assembly throughput
+ *
+ * Measures throughput of assembling chunks into files, including:
+ * - File I/O
+ * - CRC32 verification per chunk
+ * - Memory operations
+ */
+static void BM_SingleFile_AssemblyThroughput(::benchmark::State& state) {
+    const auto file_size = static_cast<std::size_t>(state.range(0));
+
+    temp_file_manager temp_files;
+    auto source_file = temp_files.create_random_file("assembly_source.bin", file_size, 42);
+
+    // Pre-split the file
+    chunk_config config(sizes::default_chunk);
+    chunk_splitter splitter(config);
+    std::vector<chunk> chunks;
+
+    auto id = transfer_id::generate();
+    auto split_result = splitter.split(source_file, id);
+    if (!split_result) {
+        state.SkipWithError("Failed to split source file");
+        return;
+    }
+
+    auto& iterator = split_result.value();
+    while (iterator.has_next()) {
+        auto chunk_result = iterator.next();
+        if (chunk_result) {
+            chunks.push_back(std::move(chunk_result.value()));
+        }
+    }
+
+    for (auto _ : state) {
+        state.PauseTiming();
+        auto output_dir = std::filesystem::temp_directory_path() / "bench_throughput_output";
+        std::filesystem::create_directories(output_dir);
+        chunk_assembler assembler(output_dir);
+
+        auto new_id = transfer_id::generate();
+        std::vector<chunk> session_chunks;
+        session_chunks.reserve(chunks.size());
+        for (const auto& c : chunks) {
+            chunk new_chunk = c;
+            new_chunk.header.id = new_id;
+            session_chunks.push_back(std::move(new_chunk));
+        }
+
+        auto start_result = assembler.start_session(
+            new_id, "assembled_output.bin", file_size, chunks.size());
+        if (!start_result) {
+            state.SkipWithError("Failed to start assembly session");
+            std::filesystem::remove_all(output_dir);
+            return;
+        }
+        state.ResumeTiming();
+
+        for (auto& chunk : session_chunks) {
+            auto process_result = assembler.process_chunk(chunk);
+            if (!process_result) {
+                state.PauseTiming();
+                assembler.cancel_session(new_id);
+                std::filesystem::remove_all(output_dir);
+                state.ResumeTiming();
+                state.SkipWithError("Failed to process chunk");
+                return;
+            }
+        }
+
+        state.PauseTiming();
+        assembler.cancel_session(new_id);
+        std::filesystem::remove_all(output_dir);
+        state.ResumeTiming();
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(file_size) *
+                           static_cast<int64_t>(state.iterations()));
+    state.counters["chunks"] = static_cast<double>(chunks.size());
+    state.counters["throughput_MB_s"] =
+        ::benchmark::Counter(static_cast<double>(file_size) / sizes::MB,
+                            ::benchmark::Counter::kIsIterationInvariantRate);
+}
+
+/**
+ * @brief Benchmark for round-trip throughput (split + assemble)
+ *
+ * Measures end-to-end throughput including splitting and assembly
+ */
+static void BM_SingleFile_RoundTripThroughput(::benchmark::State& state) {
+    const auto file_size = static_cast<std::size_t>(state.range(0));
+
+    temp_file_manager temp_files;
+    auto source_file = temp_files.create_random_file("roundtrip_source.bin", file_size, 42);
+
+    chunk_config config(sizes::default_chunk);
+
+    for (auto _ : state) {
+        // Split phase
+        chunk_splitter splitter(config);
+        auto id = transfer_id::generate();
+        auto split_result = splitter.split(source_file, id);
+
+        if (!split_result) {
+            state.SkipWithError("Failed to create splitter");
+            return;
+        }
+
+        std::vector<chunk> chunks;
+        auto& iterator = split_result.value();
+        while (iterator.has_next()) {
+            auto chunk_result = iterator.next();
+            if (chunk_result) {
+                chunks.push_back(std::move(chunk_result.value()));
+            }
+        }
+
+        // Assembly phase
+        state.PauseTiming();
+        auto output_dir = std::filesystem::temp_directory_path() / "bench_roundtrip_output";
+        std::filesystem::create_directories(output_dir);
+        state.ResumeTiming();
+
+        chunk_assembler assembler(output_dir);
+        auto start_result = assembler.start_session(
+            id, "roundtrip_output.bin", file_size, chunks.size());
+
+        if (!start_result) {
+            state.PauseTiming();
+            std::filesystem::remove_all(output_dir);
+            state.ResumeTiming();
+            state.SkipWithError("Failed to start assembly session");
+            return;
+        }
+
+        for (auto& chunk : chunks) {
+            auto process_result = assembler.process_chunk(chunk);
+            if (!process_result) {
+                state.PauseTiming();
+                assembler.cancel_session(id);
+                std::filesystem::remove_all(output_dir);
+                state.ResumeTiming();
+                state.SkipWithError("Failed to process chunk");
+                return;
+            }
+        }
+
+        state.PauseTiming();
+        assembler.cancel_session(id);
+        std::filesystem::remove_all(output_dir);
+        state.ResumeTiming();
+    }
+
+    // Report throughput (file size * 2 for split + assembly)
+    state.SetBytesProcessed(static_cast<int64_t>(file_size) * 2 *
+                           static_cast<int64_t>(state.iterations()));
+    state.counters["throughput_MB_s"] =
+        ::benchmark::Counter(static_cast<double>(file_size) * 2 / sizes::MB,
+                            ::benchmark::Counter::kIsIterationInvariantRate);
+}
+
+/**
+ * @brief Benchmark for chunk size impact on throughput
+ */
+static void BM_SingleFile_ChunkSizeImpact(::benchmark::State& state) {
+    const auto file_size = sizes::large_file;  // Fixed 100MB file
+    const auto chunk_size = static_cast<std::size_t>(state.range(0));
+
+    temp_file_manager temp_files;
+    auto test_file = temp_files.create_random_file("chunk_size_test.bin", file_size, 42);
+
+    chunk_config config(chunk_size);
+    chunk_splitter splitter(config);
+
+    uint64_t total_chunks = 0;
+
+    for (auto _ : state) {
+        auto id = transfer_id::generate();
+        auto result = splitter.split(test_file, id);
+
+        if (!result) {
+            state.SkipWithError("Failed to create splitter iterator");
+            return;
+        }
+
+        auto& iterator = result.value();
+        uint64_t chunks_processed = 0;
+
+        while (iterator.has_next()) {
+            auto chunk_result = iterator.next();
+            if (!chunk_result) {
+                state.SkipWithError("Failed to get chunk");
+                return;
+            }
+            ++chunks_processed;
+            ::benchmark::DoNotOptimize(chunk_result.value());
+        }
+
+        total_chunks = chunks_processed;
+    }
+
+    state.SetBytesProcessed(static_cast<int64_t>(file_size) *
+                           static_cast<int64_t>(state.iterations()));
+    state.counters["chunks"] = static_cast<double>(total_chunks);
+    state.counters["chunk_size_KB"] = static_cast<double>(chunk_size / sizes::KB);
+}
+
+// Register split throughput benchmarks
+BENCHMARK(BM_SingleFile_SplitThroughput)
+    ->Arg(static_cast<int64_t>(sizes::small_file))    // 100 KB
+    ->Arg(static_cast<int64_t>(sizes::medium_file))   // 10 MB
+    ->Arg(static_cast<int64_t>(sizes::large_file))    // 100 MB
+    ->Unit(::benchmark::kMillisecond)
+    ->Iterations(10);
+
+// Register assembly throughput benchmarks
+BENCHMARK(BM_SingleFile_AssemblyThroughput)
+    ->Arg(static_cast<int64_t>(sizes::small_file))
+    ->Arg(static_cast<int64_t>(sizes::medium_file))
+    ->Arg(static_cast<int64_t>(sizes::large_file))
+    ->Unit(::benchmark::kMillisecond)
+    ->Iterations(10);
+
+// Register round-trip throughput benchmarks
+BENCHMARK(BM_SingleFile_RoundTripThroughput)
+    ->Arg(static_cast<int64_t>(sizes::small_file))
+    ->Arg(static_cast<int64_t>(sizes::medium_file))
+    ->Arg(static_cast<int64_t>(sizes::large_file))
+    ->Unit(::benchmark::kMillisecond)
+    ->Iterations(5);
+
+// Register chunk size impact benchmarks
+BENCHMARK(BM_SingleFile_ChunkSizeImpact)
+    ->Arg(static_cast<int64_t>(sizes::min_chunk))      // 64 KB
+    ->Arg(static_cast<int64_t>(128 * sizes::KB))       // 128 KB
+    ->Arg(static_cast<int64_t>(sizes::default_chunk))  // 256 KB
+    ->Arg(static_cast<int64_t>(512 * sizes::KB))       // 512 KB
+    ->Arg(static_cast<int64_t>(sizes::max_chunk))      // 1 MB
+    ->Unit(::benchmark::kMillisecond)
+    ->Iterations(10);
+
+}  // namespace kcenon::file_transfer::benchmark

--- a/benchmarks/utils/benchmark_helpers.cpp
+++ b/benchmarks/utils/benchmark_helpers.cpp
@@ -1,0 +1,204 @@
+/**
+ * @file benchmark_helpers.cpp
+ * @brief Implementation of benchmark helper utilities
+ */
+
+#include "utils/benchmark_helpers.h"
+
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+
+namespace kcenon::file_transfer::benchmark {
+
+// test_data_generator implementation
+
+auto test_data_generator::generate_random_data(std::size_t size, uint32_t seed)
+    -> std::vector<std::byte> {
+    std::vector<std::byte> data(size);
+
+    std::mt19937 gen(seed == 0 ? std::random_device{}() : seed);
+    std::uniform_int_distribution<uint16_t> dis(0, 255);
+
+    for (auto& byte : data) {
+        byte = static_cast<std::byte>(dis(gen));
+    }
+
+    return data;
+}
+
+auto test_data_generator::generate_text_data(std::size_t size, uint32_t seed)
+    -> std::vector<std::byte> {
+    std::vector<std::byte> data;
+    data.reserve(size);
+
+    std::mt19937 gen(seed == 0 ? std::random_device{}() : seed);
+
+    // Common English words for generating compressible text
+    static const std::vector<std::string> words = {
+        "the", "be", "to", "of", "and", "a", "in", "that", "have", "I",
+        "it", "for", "not", "on", "with", "he", "as", "you", "do", "at",
+        "this", "but", "his", "by", "from", "they", "we", "say", "her", "she",
+        "or", "an", "will", "my", "one", "all", "would", "there", "their", "what",
+        "so", "up", "out", "if", "about", "who", "get", "which", "go", "me",
+        "file", "transfer", "data", "system", "server", "client", "chunk", "byte",
+        "network", "protocol", "connection", "upload", "download", "compress"
+    };
+
+    std::uniform_int_distribution<std::size_t> word_dis(0, words.size() - 1);
+    std::uniform_int_distribution<int> space_dis(0, 10);
+
+    while (data.size() < size) {
+        const auto& word = words[word_dis(gen)];
+        for (char c : word) {
+            if (data.size() >= size) break;
+            data.push_back(static_cast<std::byte>(c));
+        }
+
+        if (data.size() < size) {
+            // Add space or newline
+            if (space_dis(gen) == 0) {
+                data.push_back(static_cast<std::byte>('\n'));
+            } else {
+                data.push_back(static_cast<std::byte>(' '));
+            }
+        }
+    }
+
+    data.resize(size);
+    return data;
+}
+
+auto test_data_generator::generate_data_with_compressibility(
+    std::size_t size,
+    double compressibility_ratio,
+    uint32_t seed) -> std::vector<std::byte> {
+    std::vector<std::byte> data(size);
+
+    std::mt19937 gen(seed == 0 ? std::random_device{}() : seed);
+
+    // Calculate how many unique values to use
+    // Higher compressibility = fewer unique values = more repetition
+    auto unique_values = static_cast<int>(256 * (1.0 - compressibility_ratio));
+    if (unique_values < 1) unique_values = 1;
+    if (unique_values > 256) unique_values = 256;
+
+    std::uniform_int_distribution<int> dis(0, unique_values - 1);
+
+    for (auto& byte : data) {
+        byte = static_cast<std::byte>(dis(gen));
+    }
+
+    return data;
+}
+
+// temp_file_manager implementation
+
+temp_file_manager::temp_file_manager(const std::filesystem::path& base_dir) {
+    if (base_dir.empty()) {
+        base_dir_ = std::filesystem::temp_directory_path() / "file_trans_benchmarks";
+        owns_dir_ = true;
+    } else {
+        base_dir_ = base_dir;
+        owns_dir_ = false;
+    }
+
+    std::error_code ec;
+    std::filesystem::create_directories(base_dir_, ec);
+}
+
+temp_file_manager::~temp_file_manager() {
+    cleanup();
+}
+
+temp_file_manager::temp_file_manager(temp_file_manager&& other) noexcept
+    : base_dir_(std::move(other.base_dir_)),
+      created_files_(std::move(other.created_files_)),
+      owns_dir_(other.owns_dir_) {
+    other.owns_dir_ = false;
+}
+
+auto temp_file_manager::operator=(temp_file_manager&& other) noexcept -> temp_file_manager& {
+    if (this != &other) {
+        cleanup();
+        base_dir_ = std::move(other.base_dir_);
+        created_files_ = std::move(other.created_files_);
+        owns_dir_ = other.owns_dir_;
+        other.owns_dir_ = false;
+    }
+    return *this;
+}
+
+auto temp_file_manager::create_file(
+    const std::string& name,
+    const std::vector<std::byte>& data) -> std::filesystem::path {
+    auto path = base_dir_ / name;
+    std::ofstream file(path, std::ios::binary);
+    file.write(reinterpret_cast<const char*>(data.data()),
+               static_cast<std::streamsize>(data.size()));
+    created_files_.push_back(path);
+    return path;
+}
+
+auto temp_file_manager::create_random_file(
+    const std::string& name,
+    std::size_t size,
+    uint32_t seed) -> std::filesystem::path {
+    auto data = test_data_generator::generate_random_data(size, seed);
+    return create_file(name, data);
+}
+
+auto temp_file_manager::base_dir() const -> const std::filesystem::path& {
+    return base_dir_;
+}
+
+void temp_file_manager::cleanup() {
+    std::error_code ec;
+
+    for (const auto& path : created_files_) {
+        std::filesystem::remove(path, ec);
+    }
+    created_files_.clear();
+
+    if (owns_dir_) {
+        std::filesystem::remove_all(base_dir_, ec);
+    }
+}
+
+// Utility functions
+
+auto format_bytes(uint64_t bytes) -> std::string {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    if (bytes >= sizes::GB) {
+        oss << static_cast<double>(bytes) / sizes::GB << " GB";
+    } else if (bytes >= sizes::MB) {
+        oss << static_cast<double>(bytes) / sizes::MB << " MB";
+    } else if (bytes >= sizes::KB) {
+        oss << static_cast<double>(bytes) / sizes::KB << " KB";
+    } else {
+        oss << bytes << " B";
+    }
+
+    return oss.str();
+}
+
+auto format_throughput(double bytes_per_second) -> std::string {
+    std::ostringstream oss;
+    oss << std::fixed << std::setprecision(2);
+
+    if (bytes_per_second >= sizes::GB) {
+        oss << bytes_per_second / sizes::GB << " GB/s";
+    } else if (bytes_per_second >= sizes::MB) {
+        oss << bytes_per_second / sizes::MB << " MB/s";
+    } else if (bytes_per_second >= sizes::KB) {
+        oss << bytes_per_second / sizes::KB << " KB/s";
+    } else {
+        oss << bytes_per_second << " B/s";
+    }
+
+    return oss.str();
+}
+
+}  // namespace kcenon::file_transfer::benchmark

--- a/benchmarks/utils/benchmark_helpers.h
+++ b/benchmarks/utils/benchmark_helpers.h
@@ -1,0 +1,169 @@
+/**
+ * @file benchmark_helpers.h
+ * @brief Helper utilities for benchmarks
+ */
+
+#ifndef KCENON_FILE_TRANSFER_BENCHMARKS_BENCHMARK_HELPERS_H
+#define KCENON_FILE_TRANSFER_BENCHMARKS_BENCHMARK_HELPERS_H
+
+#include <cstddef>
+#include <filesystem>
+#include <random>
+#include <string>
+#include <vector>
+
+namespace kcenon::file_transfer::benchmark {
+
+/**
+ * @brief Helper class for generating test data for benchmarks
+ */
+class test_data_generator {
+public:
+    /**
+     * @brief Generate random binary data
+     * @param size Size in bytes
+     * @param seed Random seed (0 for random)
+     * @return Vector of random bytes
+     */
+    static auto generate_random_data(std::size_t size, uint32_t seed = 0)
+        -> std::vector<std::byte>;
+
+    /**
+     * @brief Generate compressible text data
+     * @param size Approximate size in bytes
+     * @param seed Random seed (0 for random)
+     * @return Vector of text-like bytes
+     */
+    static auto generate_text_data(std::size_t size, uint32_t seed = 0)
+        -> std::vector<std::byte>;
+
+    /**
+     * @brief Generate data with specified compressibility ratio
+     * @param size Size in bytes
+     * @param compressibility_ratio 0.0 = random, 1.0 = highly compressible
+     * @param seed Random seed (0 for random)
+     * @return Vector of bytes
+     */
+    static auto generate_data_with_compressibility(
+        std::size_t size,
+        double compressibility_ratio,
+        uint32_t seed = 0) -> std::vector<std::byte>;
+};
+
+/**
+ * @brief Helper class for managing temporary benchmark files
+ */
+class temp_file_manager {
+public:
+    /**
+     * @brief Constructor
+     * @param base_dir Base directory for temporary files
+     */
+    explicit temp_file_manager(const std::filesystem::path& base_dir = {});
+
+    /**
+     * @brief Destructor - cleans up temporary files
+     */
+    ~temp_file_manager();
+
+    // Non-copyable
+    temp_file_manager(const temp_file_manager&) = delete;
+    auto operator=(const temp_file_manager&) -> temp_file_manager& = delete;
+
+    // Movable
+    temp_file_manager(temp_file_manager&&) noexcept;
+    auto operator=(temp_file_manager&&) noexcept -> temp_file_manager&;
+
+    /**
+     * @brief Create a temporary file with the given content
+     * @param name File name
+     * @param data File content
+     * @return Path to created file
+     */
+    auto create_file(const std::string& name, const std::vector<std::byte>& data)
+        -> std::filesystem::path;
+
+    /**
+     * @brief Create a temporary file with random data
+     * @param name File name
+     * @param size File size
+     * @param seed Random seed
+     * @return Path to created file
+     */
+    auto create_random_file(const std::string& name, std::size_t size, uint32_t seed = 0)
+        -> std::filesystem::path;
+
+    /**
+     * @brief Get the base directory
+     * @return Base directory path
+     */
+    [[nodiscard]] auto base_dir() const -> const std::filesystem::path&;
+
+    /**
+     * @brief Clean up all temporary files
+     */
+    void cleanup();
+
+private:
+    std::filesystem::path base_dir_;
+    std::vector<std::filesystem::path> created_files_;
+    bool owns_dir_ = false;
+};
+
+/**
+ * @brief Format bytes as human-readable string
+ * @param bytes Number of bytes
+ * @return Formatted string (e.g., "1.5 GB")
+ */
+auto format_bytes(uint64_t bytes) -> std::string;
+
+/**
+ * @brief Format throughput as human-readable string
+ * @param bytes_per_second Throughput in bytes per second
+ * @return Formatted string (e.g., "500 MB/s")
+ */
+auto format_throughput(double bytes_per_second) -> std::string;
+
+/**
+ * @brief Size constants for benchmarks
+ */
+namespace sizes {
+constexpr std::size_t KB = 1024;
+constexpr std::size_t MB = 1024 * KB;
+constexpr std::size_t GB = 1024 * MB;
+
+constexpr std::size_t small_file = 100 * KB;    // 100 KB
+constexpr std::size_t medium_file = 10 * MB;    // 10 MB
+constexpr std::size_t large_file = 100 * MB;    // 100 MB
+constexpr std::size_t xlarge_file = 1 * GB;     // 1 GB
+
+// Chunk sizes for testing
+constexpr std::size_t min_chunk = 64 * KB;      // 64 KB
+constexpr std::size_t default_chunk = 256 * KB; // 256 KB
+constexpr std::size_t max_chunk = 1 * MB;       // 1 MB
+}  // namespace sizes
+
+/**
+ * @brief Performance targets from SRS
+ */
+namespace targets {
+// Throughput targets
+constexpr double lan_throughput_mbps = 500.0;      // >= 500 MB/s LAN
+constexpr double wan_throughput_mbps = 100.0;      // >= 100 MB/s WAN
+
+// Compression targets
+constexpr double lz4_compress_mbps = 400.0;        // >= 400 MB/s
+constexpr double lz4_decompress_mbps = 1500.0;     // >= 1.5 GB/s
+
+// Memory targets (bytes)
+constexpr std::size_t server_memory = 100 * sizes::MB;  // < 100 MB
+constexpr std::size_t client_memory = 50 * sizes::MB;   // < 50 MB
+constexpr std::size_t per_connection = 1 * sizes::MB;   // < 1 MB
+
+// Latency targets
+constexpr double file_list_response_ms = 100.0;    // < 100ms for 10K files
+}  // namespace targets
+
+}  // namespace kcenon::file_transfer::benchmark
+
+#endif  // KCENON_FILE_TRANSFER_BENCHMARKS_BENCHMARK_HELPERS_H


### PR DESCRIPTION
## Summary

- Integrate Google Benchmark 1.8.3 framework via FetchContent
- Add benchmark utilities for test data generation and temp file management
- Implement throughput benchmarks for chunk splitting and assembly operations
- Add single file throughput benchmarks (split, assembly, round-trip)
- Add checksum benchmarks (CRC32, SHA-256)
- Update README.md and README_KR.md with benchmark usage instructions
- Add benchmarks/README.md with detailed documentation

## Test plan

- [x] Build with `-DFILE_TRANS_BUILD_BENCHMARKS=ON`
- [x] Run `./bin/throughput_benchmarks` to verify benchmarks execute correctly
- [x] Verify JSON output format works

Closes #34