### PR TITLE
refactor(config): adopt unified KCENON_* feature flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -244,12 +244,20 @@ endif()
 # Ecosystem dependencies
 if(BUILD_WITH_COMMON_SYSTEM AND COMMON_SYSTEM_INCLUDE_DIR)
     target_include_directories(FileTransSystem PUBLIC ${COMMON_SYSTEM_INCLUDE_DIR})
-    target_compile_definitions(FileTransSystem PUBLIC BUILD_WITH_COMMON_SYSTEM)
+    # Define both legacy and new unified macros for compatibility
+    target_compile_definitions(FileTransSystem PUBLIC
+        BUILD_WITH_COMMON_SYSTEM
+        KCENON_WITH_COMMON_SYSTEM=1
+    )
 endif()
 
 if(BUILD_WITH_THREAD_SYSTEM AND THREAD_SYSTEM_INCLUDE_DIR)
     target_include_directories(FileTransSystem PUBLIC ${THREAD_SYSTEM_INCLUDE_DIR})
-    target_compile_definitions(FileTransSystem PUBLIC BUILD_WITH_THREAD_SYSTEM)
+    # Define both legacy and new unified macros for compatibility
+    target_compile_definitions(FileTransSystem PUBLIC
+        BUILD_WITH_THREAD_SYSTEM
+        KCENON_WITH_THREAD_SYSTEM=1
+    )
 
     # Link thread_system library
     if(THREAD_SYSTEM_LIBRARY)
@@ -259,7 +267,11 @@ endif()
 
 if(BUILD_WITH_NETWORK_SYSTEM AND NETWORK_SYSTEM_INCLUDE_DIR)
     target_include_directories(FileTransSystem PUBLIC ${NETWORK_SYSTEM_INCLUDE_DIR})
-    target_compile_definitions(FileTransSystem PUBLIC BUILD_WITH_NETWORK_SYSTEM)
+    # Define both legacy and new unified macros for compatibility
+    target_compile_definitions(FileTransSystem PUBLIC
+        BUILD_WITH_NETWORK_SYSTEM
+        KCENON_WITH_NETWORK_SYSTEM=1
+    )
 
     # Link network_system library
     if(NETWORK_SYSTEM_LIBRARY)
@@ -281,12 +293,20 @@ endif()
 
 if(BUILD_WITH_CONTAINER_SYSTEM AND CONTAINER_SYSTEM_INCLUDE_DIR)
     target_include_directories(FileTransSystem PUBLIC ${CONTAINER_SYSTEM_INCLUDE_DIR})
-    target_compile_definitions(FileTransSystem PUBLIC BUILD_WITH_CONTAINER_SYSTEM)
+    # Define both legacy and new unified macros for compatibility
+    target_compile_definitions(FileTransSystem PUBLIC
+        BUILD_WITH_CONTAINER_SYSTEM
+        KCENON_WITH_CONTAINER_SYSTEM=1
+    )
 endif()
 
 if(BUILD_WITH_LOGGER_SYSTEM AND LOGGER_SYSTEM_INCLUDE_DIR)
     target_include_directories(FileTransSystem PUBLIC ${LOGGER_SYSTEM_INCLUDE_DIR})
-    target_compile_definitions(FileTransSystem PUBLIC BUILD_WITH_LOGGER_SYSTEM)
+    # Define both legacy and new unified macros for compatibility
+    target_compile_definitions(FileTransSystem PUBLIC
+        BUILD_WITH_LOGGER_SYSTEM
+        KCENON_WITH_LOGGER_SYSTEM=1
+    )
 
     # Link logger_system library
     if(LOGGER_SYSTEM_LIBRARY)

--- a/docs/reference/logging.md
+++ b/docs/reference/logging.md
@@ -255,7 +255,7 @@ log_config defaults = log_config::defaults();
 
 ## Integration with logger_system
 
-When both `BUILD_WITH_LOGGER_SYSTEM` and `BUILD_WITH_COMMON_SYSTEM` are enabled,
+When `KCENON_WITH_LOGGER_SYSTEM` is enabled (or legacy `BUILD_WITH_LOGGER_SYSTEM` and `BUILD_WITH_COMMON_SYSTEM`),
 the logging system automatically integrates with `logger_system` for:
 
 - Asynchronous logging

--- a/include/kcenon/file_transfer/core/logging.h
+++ b/include/kcenon/file_transfer/core/logging.h
@@ -22,9 +22,21 @@
 #include <unordered_map>
 #include <fstream>
 
-// logger_system integration requires common_system
-#if defined(BUILD_WITH_LOGGER_SYSTEM) && defined(BUILD_WITH_COMMON_SYSTEM)
+// Include unified feature flags from common_system if available
+#if __has_include(<kcenon/common/config/feature_flags.h>)
+#include <kcenon/common/config/feature_flags.h>
+#endif
+
+// logger_system integration detection
+// Uses KCENON_WITH_LOGGER_SYSTEM from unified feature flags (preferred)
+// Falls back to BUILD_WITH_* macros for backward compatibility
+#if defined(KCENON_WITH_LOGGER_SYSTEM) && KCENON_WITH_LOGGER_SYSTEM
 #define FILE_TRANSFER_USE_LOGGER_SYSTEM 1
+#elif defined(BUILD_WITH_LOGGER_SYSTEM) && defined(BUILD_WITH_COMMON_SYSTEM)
+#define FILE_TRANSFER_USE_LOGGER_SYSTEM 1
+#endif
+
+#ifdef FILE_TRANSFER_USE_LOGGER_SYSTEM
 #include <kcenon/logger/core/logger.h>
 #include <kcenon/logger/core/logger_builder.h>
 #include <kcenon/logger/writers/console_writer.h>


### PR DESCRIPTION
## Summary
- Replace BUILD_WITH_* macros with KCENON_WITH_* equivalents
- Include feature_flags.h from common_system (guarded with __has_include)
- Maintain backward compatibility with legacy macros

## Changes

### Headers
- `logging.h`: Include feature_flags.h, use KCENON_WITH_LOGGER_SYSTEM for integration detection

### CMake
- `CMakeLists.txt`: Define both legacy and new unified macros (KCENON_WITH_*) for all system integrations

### Documentation
- `docs/reference/logging.md`: Updated to reference KCENON_WITH_LOGGER_SYSTEM

## Related Issues
- Parent: kcenon/common_system#223 (Epic: Unified feature-flag consolidation)
- Closes #107

## Test plan
- [x] Build with CMake
- [x] Verify legacy BUILD_WITH_* macros still work
- [x] Verify new KCENON_WITH_* macros are defined