### PR TITLE
fix(test): upgrade GoogleTest to v1.17.0 for ABI compatibility

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -12,10 +12,11 @@ enable_testing()
 include(FetchContent)
 
 # Declare Google Test dependency
+# Note: Using v1.17.0 to match system-installed version and ensure ABI compatibility
 FetchContent_Declare(
     googletest
     GIT_REPOSITORY https://github.com/google/googletest.git
-    GIT_TAG v1.14.0
+    GIT_TAG v1.17.0
     GIT_SHALLOW TRUE
 )
 
@@ -25,8 +26,19 @@ set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
 # Disable installation of GTest
 set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
 
+# Ensure GoogleTest uses the same C++ standard as the parent project
+# This is critical for ABI compatibility on macOS/Linux with libc++
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Make available
 FetchContent_MakeAvailable(googletest)
+
+# Explicitly set C++20 on gtest targets for ABI compatibility
+set_target_properties(gtest PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
+set_target_properties(gtest_main PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
+set_target_properties(gmock PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
+set_target_properties(gmock_main PROPERTIES CXX_STANDARD 20 CXX_STANDARD_REQUIRED ON)
 
 # Include GoogleTest module for test discovery
 include(GoogleTest)


### PR DESCRIPTION
## Summary

- Upgrade GoogleTest from v1.14.0 to v1.17.0 to fix ABI mismatch
- Set C++20 standard explicitly on gtest/gmock targets
- Fix undefined symbol linker errors on macOS

## Problem

Local builds on macOS fail with linker errors:

```
Undefined symbols for architecture arm64:
  "testing::internal::MakeAndRegisterTestInfo(std::__1::basic_string<char, ...)"
```

**Root Cause**: System-installed GoogleTest v1.17.0 headers are found during compilation, but FetchContent builds v1.14.0 library. The `MakeAndRegisterTestInfo` function signature changed between versions:
- v1.14.0: `const char*` parameter
- v1.17.0: `std::string` parameter

## Changes

### tests/CMakeLists.txt
- Update `GIT_TAG` from `v1.14.0` to `v1.17.0`
- Add `CMAKE_CXX_STANDARD 20` before `FetchContent_MakeAvailable`
- Explicitly set `CXX_STANDARD 20` on gtest, gtest_main, gmock, gmock_main targets

## Test Plan

- [x] Build succeeds on macOS with AppleClang
- [x] All 606 unit tests pass
- [x] No undefined symbol errors during linking

## Related Issues

Closes #110