### PR TITLE
fix(ci): resolve Windows MSVC linker errors for network_system symbols

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -85,6 +85,23 @@ target_link_libraries(file_trans_unit_tests PRIVATE
     Threads::Threads
 )
 
+# On Windows MSVC, static library transitive dependencies are not automatically
+# propagated to executables, and the linker may not include unreferenced symbols
+# from static libraries. We use /WHOLEARCHIVE to force inclusion of all symbols
+# from network_system to resolve messaging_client external symbols.
+# See: https://gitlab.kitware.com/cmake/cmake/-/issues/18075
+if(MSVC AND NETWORK_SYSTEM_LIBRARY)
+    # Use WHOLEARCHIVE to force all symbols from network_system to be included
+    target_link_options(file_trans_unit_tests PRIVATE
+        "/WHOLEARCHIVE:${NETWORK_SYSTEM_LIBRARY}"
+    )
+    # network_system depends on OpenSSL for TLS support
+    find_package(OpenSSL QUIET)
+    if(OpenSSL_FOUND)
+        target_link_libraries(file_trans_unit_tests PRIVATE OpenSSL::SSL OpenSSL::Crypto)
+    endif()
+endif()
+
 # Set properties
 set_target_properties(file_trans_unit_tests PROPERTIES
     CXX_STANDARD 20


### PR DESCRIPTION
## Summary

- Fix Windows MSVC linker errors (LNK2019/LNK2001) for network_system symbols
- Explicitly link network_system and OpenSSL for MSVC builds in tests

## Problem

On Windows MSVC, static library transitive dependencies are not automatically propagated to executables. This caused the following linker errors when building `file_trans_unit_tests.exe`:

| Error | Symbol |
|-------|--------|
| LNK2019 | `messaging_client::start_client` |
| LNK2001 | `messaging_client::stop_client` |
| LNK2019 | `messaging_client::send_packet` |

## Root Cause

CMake's transitive linking (`PUBLIC` dependencies) works differently for static libraries on MSVC. While `FileTransSystem` links `NetworkSystem` as PUBLIC, this dependency is not automatically propagated to executables that link against `FileTransSystem`.

Reference: https://gitlab.kitware.com/cmake/cmake/-/issues/18075

## Solution

Added explicit linking for MSVC in `tests/CMakeLists.txt`:
- Link `NETWORK_SYSTEM_LIBRARY` directly for MSVC builds
- Link OpenSSL (network_system's dependency) for TLS support

## Test plan

- [ ] Windows MSVC CI build passes
- [ ] All unit tests pass on Windows
- [ ] macOS/Linux builds continue to work (verified locally)

Fixes #113