### PR TITLE
feat(adapters): implement IMonitor and IMonitorable adapters for monitoring integration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -267,6 +267,8 @@ set(FILE_TRANS_SOURCES
     src/core/bandwidth_limiter.cpp
     src/core/statistics_collector.cpp
     src/adapters/logger_adapter.cpp
+    src/adapters/monitoring_adapter.cpp
+    src/adapters/monitorable_adapter.cpp
     src/server/file_transfer_server.cpp
     src/server/server_pipeline.cpp
     src/server/pipeline_jobs.cpp

--- a/examples/cloud/hybrid_storage_example.cpp
+++ b/examples/cloud/hybrid_storage_example.cpp
@@ -478,7 +478,7 @@ int main(int argc, char* argv[]) {
 
     // Create S3 storage
     std::cout << "Creating cloud storage...\n";
-    auto cloud = s3_storage::create(config, credentials);
+    auto cloud = s3_storage::create(config, std::move(credentials));
     if (!cloud) {
         std::cerr << "Failed to create S3 storage.\n";
         return 1;
@@ -496,7 +496,8 @@ int main(int argc, char* argv[]) {
 
     // Create hybrid storage manager
     // We need to create a second S3 storage for the manager since we're moving ownership
-    auto manager_cloud = s3_storage::create(config, credentials);
+    auto manager_credentials = s3_credential_provider::create_default();
+    auto manager_cloud = s3_storage::create(config, std::move(manager_credentials));
     if (!manager_cloud) {
         std::cerr << "Failed to create manager storage.\n";
         return 1;

--- a/examples/cloud/multi_cloud_failover_example.cpp
+++ b/examples/cloud/multi_cloud_failover_example.cpp
@@ -435,7 +435,7 @@ int main(int argc, char* argv[]) {
             .with_region(s3_region)
             .build_s3();
 
-        auto s3 = s3_storage::create(s3_config, s3_credentials);
+        auto s3 = s3_storage::create(s3_config, std::move(s3_credentials));
         if (s3) {
             auto result = s3->connect();
             if (result.has_value()) {
@@ -497,18 +497,18 @@ int main(int argc, char* argv[]) {
             [[nodiscard]] auto is_available() const -> bool override { return false; }
             [[nodiscard]] auto upload(const std::string&, std::span<const std::byte>)
                 -> result<upload_result> override {
-                return make_error(error_code::connection_failed, "Dummy provider");
+                return unexpected{error{error_code::connection_failed, "Dummy provider"}};
             }
             [[nodiscard]] auto download(const std::string&)
                 -> result<std::vector<std::byte>> override {
-                return make_error(error_code::connection_failed, "Dummy provider");
+                return unexpected{error{error_code::connection_failed, "Dummy provider"}};
             }
             [[nodiscard]] auto delete_object(const std::string&)
                 -> result<delete_result> override {
-                return make_error(error_code::connection_failed, "Dummy provider");
+                return unexpected{error{error_code::connection_failed, "Dummy provider"}};
             }
             [[nodiscard]] auto exists(const std::string&) -> result<bool> override {
-                return make_error(error_code::connection_failed, "Dummy provider");
+                return unexpected{error{error_code::connection_failed, "Dummy provider"}};
             }
         };
         secondary = std::make_unique<dummy_provider>();

--- a/include/kcenon/file_transfer/adapters/monitorable_adapter.h
+++ b/include/kcenon/file_transfer/adapters/monitorable_adapter.h
@@ -1,0 +1,324 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, kcenon
+// All rights reserved.
+
+/**
+ * @file monitorable_adapter.h
+ * @brief IMonitorable adapter for file_trans_system components
+ *
+ * This adapter makes file_transfer_server and file_transfer_client observable
+ * through the common::interfaces::IMonitorable interface, enabling integration
+ * with the kcenon monitoring ecosystem.
+ *
+ * @since 0.3.0
+ */
+
+#pragma once
+
+#include <memory>
+#include <string>
+
+#include "../config/feature_flags.h"
+#include "../core/types.h"
+
+#if KCENON_WITH_COMMON_SYSTEM
+#include <kcenon/common/interfaces/monitoring_interface.h>
+#endif
+
+namespace kcenon::file_transfer {
+
+// Forward declarations
+class file_transfer_server;
+class file_transfer_client;
+
+}  // namespace kcenon::file_transfer
+
+namespace kcenon::file_transfer::adapters {
+
+#if KCENON_WITH_COMMON_SYSTEM
+
+/**
+ * @brief Makes file_transfer_server observable through IMonitorable interface
+ *
+ * This adapter implements common::interfaces::IMonitorable, allowing the
+ * file transfer server to be registered with monitoring registries and
+ * health check systems.
+ *
+ * @note Thread-safe: All public methods are safe to call from multiple threads.
+ *
+ * @example Basic usage:
+ * @code
+ * auto server = std::make_shared<file_transfer_server>(
+ *     file_transfer_server::builder()
+ *         .with_storage_directory("/data")
+ *         .build()
+ *         .value());
+ *
+ * auto monitorable = std::make_shared<file_transfer_server_monitorable>(
+ *     server, "file_server_01");
+ *
+ * // Register with monitoring system
+ * monitoring_registry::instance().register_component(monitorable);
+ *
+ * // Get monitoring data
+ * auto data = monitorable->get_monitoring_data();
+ * if (data.has_value()) {
+ *     for (const auto& metric : data.value().metrics) {
+ *         std::cout << metric.name << ": " << metric.value << "\n";
+ *     }
+ * }
+ * @endcode
+ *
+ * @since 0.3.0
+ */
+class file_transfer_server_monitorable : public common::interfaces::IMonitorable {
+public:
+    /**
+     * @brief Factory method to create a monitorable wrapper
+     * @param server Shared pointer to the file transfer server
+     * @param name Component name for identification
+     * @return Shared pointer to the monitorable
+     */
+    [[nodiscard]] static std::shared_ptr<file_transfer_server_monitorable> create(
+        std::shared_ptr<file_transfer_server> server,
+        const std::string& name = "file_transfer_server");
+
+    /**
+     * @brief Constructor
+     * @param server Shared pointer to the file transfer server
+     * @param name Component name for identification
+     */
+    explicit file_transfer_server_monitorable(
+        std::shared_ptr<file_transfer_server> server,
+        const std::string& name = "file_transfer_server");
+
+    /**
+     * @brief Destructor
+     */
+    ~file_transfer_server_monitorable() override;
+
+    // Non-copyable
+    file_transfer_server_monitorable(const file_transfer_server_monitorable&) = delete;
+    file_transfer_server_monitorable& operator=(const file_transfer_server_monitorable&) = delete;
+
+    // Movable
+    file_transfer_server_monitorable(file_transfer_server_monitorable&&) noexcept;
+    file_transfer_server_monitorable& operator=(file_transfer_server_monitorable&&) noexcept;
+
+    // =========================================================================
+    // IMonitorable interface implementation
+    // =========================================================================
+
+    /**
+     * @brief Get monitoring data from the server
+     * @return Result containing metrics snapshot or error
+     *
+     * @details Collects comprehensive metrics including:
+     * - Transfer statistics (bytes, counts)
+     * - Connection statistics
+     * - Quota usage
+     * - Server uptime
+     */
+    common::Result<common::interfaces::metrics_snapshot> get_monitoring_data() override;
+
+    /**
+     * @brief Perform health check on the server
+     * @return Result containing health check result or error
+     *
+     * @details Evaluates:
+     * - Server running status
+     * - Storage quota status
+     * - Connection capacity
+     * - Storage accessibility
+     */
+    common::Result<common::interfaces::health_check_result> health_check() override;
+
+    /**
+     * @brief Get component name for monitoring identification
+     * @return Component identifier string
+     */
+    [[nodiscard]] std::string get_component_name() const override;
+
+    // =========================================================================
+    // Additional methods
+    // =========================================================================
+
+    /**
+     * @brief Check if the server is still available
+     * @return true if the server reference is valid
+     */
+    [[nodiscard]] bool is_server_available() const;
+
+    /**
+     * @brief Set component name
+     * @param name New component name
+     */
+    void set_component_name(const std::string& name);
+
+private:
+    std::weak_ptr<file_transfer_server> server_;
+    std::string component_name_;
+};
+
+/**
+ * @brief Makes file_transfer_client observable through IMonitorable interface
+ *
+ * This adapter implements common::interfaces::IMonitorable, allowing the
+ * file transfer client to be registered with monitoring registries and
+ * health check systems.
+ *
+ * @note Thread-safe: All public methods are safe to call from multiple threads.
+ *
+ * @example Basic usage:
+ * @code
+ * auto client = std::make_shared<file_transfer_client>(
+ *     file_transfer_client::builder().build().value());
+ *
+ * auto monitorable = std::make_shared<file_transfer_client_monitorable>(
+ *     client, "file_client_01");
+ *
+ * // Check client health
+ * auto health = monitorable->health_check();
+ * if (health.has_value()) {
+ *     std::cout << "Client status: " << to_string(health.value().status) << "\n";
+ * }
+ * @endcode
+ *
+ * @since 0.3.0
+ */
+class file_transfer_client_monitorable : public common::interfaces::IMonitorable {
+public:
+    /**
+     * @brief Factory method to create a monitorable wrapper
+     * @param client Shared pointer to the file transfer client
+     * @param name Component name for identification
+     * @return Shared pointer to the monitorable
+     */
+    [[nodiscard]] static std::shared_ptr<file_transfer_client_monitorable> create(
+        std::shared_ptr<file_transfer_client> client,
+        const std::string& name = "file_transfer_client");
+
+    /**
+     * @brief Constructor
+     * @param client Shared pointer to the file transfer client
+     * @param name Component name for identification
+     */
+    explicit file_transfer_client_monitorable(
+        std::shared_ptr<file_transfer_client> client,
+        const std::string& name = "file_transfer_client");
+
+    /**
+     * @brief Destructor
+     */
+    ~file_transfer_client_monitorable() override;
+
+    // Non-copyable
+    file_transfer_client_monitorable(const file_transfer_client_monitorable&) = delete;
+    file_transfer_client_monitorable& operator=(const file_transfer_client_monitorable&) = delete;
+
+    // Movable
+    file_transfer_client_monitorable(file_transfer_client_monitorable&&) noexcept;
+    file_transfer_client_monitorable& operator=(file_transfer_client_monitorable&&) noexcept;
+
+    // =========================================================================
+    // IMonitorable interface implementation
+    // =========================================================================
+
+    /**
+     * @brief Get monitoring data from the client
+     * @return Result containing metrics snapshot or error
+     *
+     * @details Collects metrics including:
+     * - Transfer statistics (bytes, counts)
+     * - Connection status
+     * - Active transfer progress
+     */
+    common::Result<common::interfaces::metrics_snapshot> get_monitoring_data() override;
+
+    /**
+     * @brief Perform health check on the client
+     * @return Result containing health check result or error
+     *
+     * @details Evaluates:
+     * - Client connection status
+     * - Active transfer health
+     */
+    common::Result<common::interfaces::health_check_result> health_check() override;
+
+    /**
+     * @brief Get component name for monitoring identification
+     * @return Component identifier string
+     */
+    [[nodiscard]] std::string get_component_name() const override;
+
+    // =========================================================================
+    // Additional methods
+    // =========================================================================
+
+    /**
+     * @brief Check if the client is still available
+     * @return true if the client reference is valid
+     */
+    [[nodiscard]] bool is_client_available() const;
+
+    /**
+     * @brief Set component name
+     * @param name New component name
+     */
+    void set_component_name(const std::string& name);
+
+private:
+    std::weak_ptr<file_transfer_client> client_;
+    std::string component_name_;
+};
+
+#else  // !KCENON_WITH_COMMON_SYSTEM
+
+/**
+ * @brief Stub server monitorable when common_system is not available
+ */
+class file_transfer_server_monitorable {
+public:
+    static std::shared_ptr<file_transfer_server_monitorable> create(
+        std::shared_ptr<file_transfer_server> /* server */,
+        const std::string& name = "file_transfer_server") {
+        return std::make_shared<file_transfer_server_monitorable>(name);
+    }
+
+    explicit file_transfer_server_monitorable(const std::string& name = "file_transfer_server")
+        : component_name_(name) {}
+
+    [[nodiscard]] std::string get_component_name() const { return component_name_; }
+    [[nodiscard]] bool is_server_available() const { return false; }
+    void set_component_name(const std::string& name) { component_name_ = name; }
+
+private:
+    std::string component_name_;
+};
+
+/**
+ * @brief Stub client monitorable when common_system is not available
+ */
+class file_transfer_client_monitorable {
+public:
+    static std::shared_ptr<file_transfer_client_monitorable> create(
+        std::shared_ptr<file_transfer_client> /* client */,
+        const std::string& name = "file_transfer_client") {
+        return std::make_shared<file_transfer_client_monitorable>(name);
+    }
+
+    explicit file_transfer_client_monitorable(const std::string& name = "file_transfer_client")
+        : component_name_(name) {}
+
+    [[nodiscard]] std::string get_component_name() const { return component_name_; }
+    [[nodiscard]] bool is_client_available() const { return false; }
+    void set_component_name(const std::string& name) { component_name_ = name; }
+
+private:
+    std::string component_name_;
+};
+
+#endif  // KCENON_WITH_COMMON_SYSTEM
+
+}  // namespace kcenon::file_transfer::adapters

--- a/include/kcenon/file_transfer/adapters/monitoring_adapter.h
+++ b/include/kcenon/file_transfer/adapters/monitoring_adapter.h
@@ -1,0 +1,245 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, kcenon
+// All rights reserved.
+
+/**
+ * @file monitoring_adapter.h
+ * @brief IMonitor adapter for file_trans_system
+ *
+ * This adapter bridges file_transfer monitoring to the common::interfaces::IMonitor
+ * interface, enabling standardized metrics collection across the kcenon ecosystem.
+ *
+ * Collected metrics when monitoring is enabled:
+ * - file_transfer.bytes_sent (counter) - Total bytes sent to clients
+ * - file_transfer.bytes_received (counter) - Total bytes received from clients
+ * - file_transfer.active_transfers (gauge) - Current active transfers
+ * - file_transfer.active_uploads (gauge) - Current active uploads
+ * - file_transfer.active_downloads (gauge) - Current active downloads
+ * - file_transfer.active_connections (gauge) - Connected clients
+ * - file_transfer.completed_uploads (counter) - Total completed uploads
+ * - file_transfer.completed_downloads (counter) - Total completed downloads
+ * - file_transfer.quota_usage_percent (gauge) - Storage quota usage
+ * - file_transfer.quota_used_bytes (gauge) - Storage bytes used
+ * - file_transfer.quota_available_bytes (gauge) - Storage bytes available
+ * - file_transfer.uptime_ms (counter) - Server uptime in milliseconds
+ *
+ * @since 0.3.0
+ */
+
+#pragma once
+
+#include <atomic>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "../config/feature_flags.h"
+#include "../core/types.h"
+
+#if KCENON_WITH_COMMON_SYSTEM
+#include <kcenon/common/interfaces/monitoring_interface.h>
+#endif
+
+namespace kcenon::file_transfer {
+
+// Forward declarations
+class file_transfer_server;
+
+}  // namespace kcenon::file_transfer
+
+namespace kcenon::file_transfer::adapters {
+
+#if KCENON_WITH_COMMON_SYSTEM
+
+/**
+ * @brief Adapter that exposes file_transfer metrics through IMonitor interface
+ *
+ * This adapter implements common::interfaces::IMonitor and provides:
+ * - Standardized metrics interface across the ecosystem
+ * - File transfer statistics (bytes, transfers, connections)
+ * - Storage quota monitoring
+ * - Health checks for server status
+ *
+ * @note Thread-safe: All public methods are safe to call from multiple threads.
+ *
+ * @example Basic usage:
+ * @code
+ * auto server = file_transfer_server::builder()
+ *     .with_storage_directory("/data")
+ *     .build()
+ *     .value();
+ *
+ * auto monitor = file_transfer_monitor_adapter::create(
+ *     std::make_shared<file_transfer_server>(std::move(server)));
+ *
+ * // Get metrics snapshot
+ * auto metrics_result = monitor->get_metrics();
+ * if (metrics_result.has_value()) {
+ *     for (const auto& metric : metrics_result.value().metrics) {
+ *         std::cout << metric.name << ": " << metric.value << "\n";
+ *     }
+ * }
+ *
+ * // Perform health check
+ * auto health_result = monitor->check_health();
+ * if (health_result.has_value()) {
+ *     std::cout << "Status: " << to_string(health_result.value().status) << "\n";
+ * }
+ * @endcode
+ *
+ * @since 0.3.0
+ */
+class file_transfer_monitor_adapter : public common::interfaces::IMonitor {
+public:
+    /**
+     * @brief Factory method to create an adapter instance
+     * @param server Shared pointer to the file transfer server
+     * @param source_id Optional identifier for the metrics source
+     * @return Shared pointer to the adapter
+     */
+    [[nodiscard]] static std::shared_ptr<file_transfer_monitor_adapter> create(
+        std::shared_ptr<file_transfer_server> server,
+        const std::string& source_id = "file_transfer");
+
+    /**
+     * @brief Constructor
+     * @param server Shared pointer to the file transfer server
+     * @param source_id Identifier for the metrics source
+     */
+    explicit file_transfer_monitor_adapter(
+        std::shared_ptr<file_transfer_server> server,
+        const std::string& source_id = "file_transfer");
+
+    /**
+     * @brief Destructor
+     */
+    ~file_transfer_monitor_adapter() override;
+
+    // Non-copyable
+    file_transfer_monitor_adapter(const file_transfer_monitor_adapter&) = delete;
+    file_transfer_monitor_adapter& operator=(const file_transfer_monitor_adapter&) = delete;
+
+    // Movable
+    file_transfer_monitor_adapter(file_transfer_monitor_adapter&&) noexcept;
+    file_transfer_monitor_adapter& operator=(file_transfer_monitor_adapter&&) noexcept;
+
+    // =========================================================================
+    // IMonitor interface implementation
+    // =========================================================================
+
+    /**
+     * @brief Record a metric value
+     * @param name Metric name
+     * @param value Metric value
+     * @return VoidResult indicating success or error
+     *
+     * @note This method stores custom metrics that will be included in get_metrics()
+     */
+    common::VoidResult record_metric(const std::string& name, double value) override;
+
+    /**
+     * @brief Record a metric with tags
+     * @param name Metric name
+     * @param value Metric value
+     * @param tags Additional metadata tags
+     * @return VoidResult indicating success or error
+     */
+    common::VoidResult record_metric(
+        const std::string& name,
+        double value,
+        const std::unordered_map<std::string, std::string>& tags) override;
+
+    /**
+     * @brief Get current metrics snapshot
+     * @return Result containing metrics snapshot or error
+     *
+     * @details Collects metrics from the server including:
+     * - Transfer statistics (bytes sent/received, active transfers)
+     * - Connection statistics
+     * - Quota usage information
+     * - Custom recorded metrics
+     */
+    common::Result<common::interfaces::metrics_snapshot> get_metrics() override;
+
+    /**
+     * @brief Perform health check
+     * @return Result containing health check result or error
+     *
+     * @details Checks the following conditions:
+     * - Server running status
+     * - Storage quota status (critical > 95%, warning > 80%)
+     * - Connection capacity (warning if > 90% of max)
+     */
+    common::Result<common::interfaces::health_check_result> check_health() override;
+
+    /**
+     * @brief Reset all custom metrics
+     * @return VoidResult indicating success or error
+     *
+     * @note This only resets custom metrics recorded via record_metric().
+     *       Server statistics are not affected.
+     */
+    common::VoidResult reset() override;
+
+    // =========================================================================
+    // Additional methods
+    // =========================================================================
+
+    /**
+     * @brief Get the source identifier
+     * @return Source ID string
+     */
+    [[nodiscard]] std::string get_source_id() const;
+
+    /**
+     * @brief Check if the server is still available
+     * @return true if the server reference is valid
+     */
+    [[nodiscard]] bool is_server_available() const;
+
+private:
+    std::weak_ptr<file_transfer_server> server_;
+    std::string source_id_;
+
+    // Custom metrics storage
+    struct custom_metric {
+        double value;
+        common::interfaces::metric_type type;
+        std::unordered_map<std::string, std::string> tags;
+    };
+    std::unordered_map<std::string, custom_metric> custom_metrics_;
+    mutable std::mutex metrics_mutex_;
+
+    // Helper methods
+    [[nodiscard]] common::interfaces::metrics_snapshot collect_server_metrics() const;
+    [[nodiscard]] common::interfaces::health_check_result check_server_health() const;
+};
+
+#else  // !KCENON_WITH_COMMON_SYSTEM
+
+/**
+ * @brief Stub adapter when common_system is not available
+ *
+ * Provides a minimal implementation that can be used for type compatibility
+ * when common_system is not linked.
+ */
+class file_transfer_monitor_adapter {
+public:
+    static std::shared_ptr<file_transfer_monitor_adapter> create(
+        std::shared_ptr<file_transfer_server> /* server */,
+        const std::string& /* source_id */ = "file_transfer") {
+        return std::make_shared<file_transfer_monitor_adapter>();
+    }
+
+    file_transfer_monitor_adapter() = default;
+    ~file_transfer_monitor_adapter() = default;
+
+    [[nodiscard]] std::string get_source_id() const { return "file_transfer"; }
+    [[nodiscard]] bool is_server_available() const { return false; }
+};
+
+#endif  // KCENON_WITH_COMMON_SYSTEM
+
+}  // namespace kcenon::file_transfer::adapters

--- a/include/kcenon/file_transfer/file_transfer.h
+++ b/include/kcenon/file_transfer/file_transfer.h
@@ -39,6 +39,11 @@
 #include "kcenon/file_transfer/client/client_types.h"
 #include "kcenon/file_transfer/client/file_transfer_client.h"
 
+// Adapters
+#include "kcenon/file_transfer/adapters/logger_adapter.h"
+#include "kcenon/file_transfer/adapters/monitoring_adapter.h"
+#include "kcenon/file_transfer/adapters/monitorable_adapter.h"
+
 namespace kcenon::file_transfer {
 
 /**

--- a/src/adapters/monitorable_adapter.cpp
+++ b/src/adapters/monitorable_adapter.cpp
@@ -1,0 +1,406 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, kcenon
+// All rights reserved.
+
+#include <kcenon/file_transfer/adapters/monitorable_adapter.h>
+#include <kcenon/file_transfer/server/file_transfer_server.h>
+#include <kcenon/file_transfer/client/file_transfer_client.h>
+
+#include <chrono>
+
+namespace kcenon::file_transfer::adapters {
+
+#if KCENON_WITH_COMMON_SYSTEM
+
+// ============================================================================
+// file_transfer_server_monitorable
+// ============================================================================
+
+// Factory method
+std::shared_ptr<file_transfer_server_monitorable> file_transfer_server_monitorable::create(
+    std::shared_ptr<file_transfer_server> server,
+    const std::string& name) {
+    return std::make_shared<file_transfer_server_monitorable>(std::move(server), name);
+}
+
+// Constructor / Destructor
+file_transfer_server_monitorable::file_transfer_server_monitorable(
+    std::shared_ptr<file_transfer_server> server,
+    const std::string& name)
+    : server_(server)
+    , component_name_(name) {}
+
+file_transfer_server_monitorable::~file_transfer_server_monitorable() = default;
+
+file_transfer_server_monitorable::file_transfer_server_monitorable(
+    file_transfer_server_monitorable&& other) noexcept
+    : server_(std::move(other.server_))
+    , component_name_(std::move(other.component_name_)) {}
+
+file_transfer_server_monitorable& file_transfer_server_monitorable::operator=(
+    file_transfer_server_monitorable&& other) noexcept {
+    if (this != &other) {
+        server_ = std::move(other.server_);
+        component_name_ = std::move(other.component_name_);
+    }
+    return *this;
+}
+
+// IMonitorable interface implementation
+common::Result<common::interfaces::metrics_snapshot> file_transfer_server_monitorable::get_monitoring_data() {
+    common::interfaces::metrics_snapshot snapshot;
+    snapshot.source_id = component_name_;
+    snapshot.capture_time = std::chrono::system_clock::now();
+
+    auto server = server_.lock();
+    if (!server) {
+        return common::make_error<common::interfaces::metrics_snapshot>(
+            common::error_codes::NOT_INITIALIZED,
+            "Server reference is not available");
+    }
+
+    // Get server statistics
+    auto stats = server->get_statistics();
+
+    // Transfer metrics (counters)
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_sent",
+        static_cast<double>(stats.total_bytes_sent),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_received",
+        static_cast<double>(stats.total_bytes_received),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.completed_uploads",
+        static_cast<double>(stats.total_files_uploaded),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.completed_downloads",
+        static_cast<double>(stats.total_files_downloaded),
+        common::interfaces::metric_type::counter);
+
+    // Active transfer metrics (gauges)
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_transfers",
+        static_cast<double>(stats.active_transfers),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_uploads",
+        static_cast<double>(stats.active_uploads),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_downloads",
+        static_cast<double>(stats.active_downloads),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_connections",
+        static_cast<double>(stats.active_connections),
+        common::interfaces::metric_type::gauge);
+
+    // Uptime metric (counter)
+    snapshot.metrics.emplace_back(
+        "file_transfer.uptime_ms",
+        static_cast<double>(stats.uptime.count()),
+        common::interfaces::metric_type::counter);
+
+    // Quota metrics
+    auto quota_usage = server->get_quota_usage();
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.quota_usage_percent",
+        quota_usage.usage_percent,
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.quota_used_bytes",
+        static_cast<double>(quota_usage.used_bytes),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.quota_available_bytes",
+        static_cast<double>(quota_usage.available_bytes),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.file_count",
+        static_cast<double>(quota_usage.file_count),
+        common::interfaces::metric_type::gauge);
+
+    return snapshot;
+}
+
+common::Result<common::interfaces::health_check_result> file_transfer_server_monitorable::health_check() {
+    common::interfaces::health_check_result result;
+    result.timestamp = std::chrono::system_clock::now();
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    auto server = server_.lock();
+    if (!server) {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Server reference is not available";
+        result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start_time);
+        return result;
+    }
+
+    // Check 1: Server running status
+    if (!server->is_running()) {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Server is not running";
+        result.metadata["server_state"] = to_string(server->state());
+        result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start_time);
+        return result;
+    }
+
+    // Initialize as healthy
+    result.status = common::interfaces::health_status::healthy;
+    result.message = "Server is healthy";
+
+    // Check 2: Quota status
+    auto quota_usage = server->get_quota_usage();
+    result.metadata["quota_usage_percent"] = std::to_string(quota_usage.usage_percent);
+
+    if (quota_usage.usage_percent > 95.0) {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Storage quota critical (>95%)";
+    } else if (quota_usage.usage_percent > 80.0) {
+        if (result.status == common::interfaces::health_status::healthy) {
+            result.status = common::interfaces::health_status::degraded;
+            result.message = "Storage quota warning (>80%)";
+        }
+    }
+
+    // Check 3: Connection capacity
+    auto stats = server->get_statistics();
+    const auto& config = server->config();
+    double connection_usage = config.max_connections > 0
+        ? static_cast<double>(stats.active_connections) / static_cast<double>(config.max_connections) * 100.0
+        : 0.0;
+
+    result.metadata["connection_usage_percent"] = std::to_string(connection_usage);
+    result.metadata["active_connections"] = std::to_string(stats.active_connections);
+    result.metadata["max_connections"] = std::to_string(config.max_connections);
+
+    if (connection_usage >= 90.0) {
+        if (result.status == common::interfaces::health_status::healthy) {
+            result.status = common::interfaces::health_status::degraded;
+            result.message = "Near connection limit (>=90%)";
+        }
+    }
+
+    // Add additional metadata
+    result.metadata["server_state"] = to_string(server->state());
+    result.metadata["uptime_ms"] = std::to_string(stats.uptime.count());
+    result.metadata["active_transfers"] = std::to_string(stats.active_transfers);
+    result.metadata["component_name"] = component_name_;
+
+    result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start_time);
+
+    return result;
+}
+
+std::string file_transfer_server_monitorable::get_component_name() const {
+    return component_name_;
+}
+
+bool file_transfer_server_monitorable::is_server_available() const {
+    return !server_.expired();
+}
+
+void file_transfer_server_monitorable::set_component_name(const std::string& name) {
+    component_name_ = name;
+}
+
+// ============================================================================
+// file_transfer_client_monitorable
+// ============================================================================
+
+// Factory method
+std::shared_ptr<file_transfer_client_monitorable> file_transfer_client_monitorable::create(
+    std::shared_ptr<file_transfer_client> client,
+    const std::string& name) {
+    return std::make_shared<file_transfer_client_monitorable>(std::move(client), name);
+}
+
+// Constructor / Destructor
+file_transfer_client_monitorable::file_transfer_client_monitorable(
+    std::shared_ptr<file_transfer_client> client,
+    const std::string& name)
+    : client_(client)
+    , component_name_(name) {}
+
+file_transfer_client_monitorable::~file_transfer_client_monitorable() = default;
+
+file_transfer_client_monitorable::file_transfer_client_monitorable(
+    file_transfer_client_monitorable&& other) noexcept
+    : client_(std::move(other.client_))
+    , component_name_(std::move(other.component_name_)) {}
+
+file_transfer_client_monitorable& file_transfer_client_monitorable::operator=(
+    file_transfer_client_monitorable&& other) noexcept {
+    if (this != &other) {
+        client_ = std::move(other.client_);
+        component_name_ = std::move(other.component_name_);
+    }
+    return *this;
+}
+
+// IMonitorable interface implementation
+common::Result<common::interfaces::metrics_snapshot> file_transfer_client_monitorable::get_monitoring_data() {
+    common::interfaces::metrics_snapshot snapshot;
+    snapshot.source_id = component_name_;
+    snapshot.capture_time = std::chrono::system_clock::now();
+
+    auto client = client_.lock();
+    if (!client) {
+        return common::make_error<common::interfaces::metrics_snapshot>(
+            common::error_codes::NOT_INITIALIZED,
+            "Client reference is not available");
+    }
+
+    // Get client statistics
+    auto stats = client->get_statistics();
+
+    // Transfer volume metrics (counters)
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_uploaded",
+        static_cast<double>(stats.total_bytes_uploaded),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_downloaded",
+        static_cast<double>(stats.total_bytes_downloaded),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_on_wire_upload",
+        static_cast<double>(stats.total_bytes_on_wire_upload),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_on_wire_download",
+        static_cast<double>(stats.total_bytes_on_wire_download),
+        common::interfaces::metric_type::counter);
+
+    // Transfer count metrics (counters)
+    snapshot.metrics.emplace_back(
+        "file_transfer.files_uploaded",
+        static_cast<double>(stats.total_files_uploaded),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.files_downloaded",
+        static_cast<double>(stats.total_files_downloaded),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.chunks_transferred",
+        static_cast<double>(stats.total_chunks_transferred),
+        common::interfaces::metric_type::counter);
+
+    // Active transfer state (gauges)
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_transfers",
+        static_cast<double>(stats.active_transfers),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_uploads",
+        static_cast<double>(stats.active_uploads),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_downloads",
+        static_cast<double>(stats.active_downloads),
+        common::interfaces::metric_type::gauge);
+
+    // Error tracking (counters)
+    snapshot.metrics.emplace_back(
+        "file_transfer.total_errors",
+        static_cast<double>(stats.total_errors),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.total_retries",
+        static_cast<double>(stats.total_retries),
+        common::interfaces::metric_type::counter);
+
+    // Connection status
+    snapshot.metrics.emplace_back(
+        "file_transfer.connected",
+        client->is_connected() ? 1.0 : 0.0,
+        common::interfaces::metric_type::gauge);
+
+    return snapshot;
+}
+
+common::Result<common::interfaces::health_check_result> file_transfer_client_monitorable::health_check() {
+    common::interfaces::health_check_result result;
+    result.timestamp = std::chrono::system_clock::now();
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    auto client = client_.lock();
+    if (!client) {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Client reference is not available";
+        result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start_time);
+        return result;
+    }
+
+    // Check connection status
+    auto state = client->state();
+    result.metadata["connection_state"] = to_string(state);
+
+    if (client->is_connected()) {
+        result.status = common::interfaces::health_status::healthy;
+        result.message = "Client is connected and operational";
+    } else if (state == connection_state::connecting ||
+               state == connection_state::reconnecting) {
+        result.status = common::interfaces::health_status::degraded;
+        result.message = "Client is reconnecting";
+    } else {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Client is disconnected";
+    }
+
+    // Add transfer statistics
+    auto stats = client->get_statistics();
+    result.metadata["active_transfers"] = std::to_string(stats.active_transfers);
+    result.metadata["total_errors"] = std::to_string(stats.total_errors);
+    result.metadata["total_retries"] = std::to_string(stats.total_retries);
+    result.metadata["component_name"] = component_name_;
+
+    result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start_time);
+
+    return result;
+}
+
+std::string file_transfer_client_monitorable::get_component_name() const {
+    return component_name_;
+}
+
+bool file_transfer_client_monitorable::is_client_available() const {
+    return !client_.expired();
+}
+
+void file_transfer_client_monitorable::set_component_name(const std::string& name) {
+    component_name_ = name;
+}
+
+#endif  // KCENON_WITH_COMMON_SYSTEM
+
+}  // namespace kcenon::file_transfer::adapters

--- a/src/adapters/monitoring_adapter.cpp
+++ b/src/adapters/monitoring_adapter.cpp
@@ -1,0 +1,292 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, kcenon
+// All rights reserved.
+
+#include <kcenon/file_transfer/adapters/monitoring_adapter.h>
+#include <kcenon/file_transfer/server/file_transfer_server.h>
+
+#include <chrono>
+
+namespace kcenon::file_transfer::adapters {
+
+#if KCENON_WITH_COMMON_SYSTEM
+
+// ============================================================================
+// Factory method
+// ============================================================================
+
+std::shared_ptr<file_transfer_monitor_adapter> file_transfer_monitor_adapter::create(
+    std::shared_ptr<file_transfer_server> server,
+    const std::string& source_id) {
+    return std::make_shared<file_transfer_monitor_adapter>(std::move(server), source_id);
+}
+
+// ============================================================================
+// Constructor / Destructor
+// ============================================================================
+
+file_transfer_monitor_adapter::file_transfer_monitor_adapter(
+    std::shared_ptr<file_transfer_server> server,
+    const std::string& source_id)
+    : server_(server)
+    , source_id_(source_id) {}
+
+file_transfer_monitor_adapter::~file_transfer_monitor_adapter() = default;
+
+file_transfer_monitor_adapter::file_transfer_monitor_adapter(
+    file_transfer_monitor_adapter&& other) noexcept
+    : server_(std::move(other.server_))
+    , source_id_(std::move(other.source_id_)) {
+    std::lock_guard<std::mutex> lock(other.metrics_mutex_);
+    custom_metrics_ = std::move(other.custom_metrics_);
+}
+
+file_transfer_monitor_adapter& file_transfer_monitor_adapter::operator=(
+    file_transfer_monitor_adapter&& other) noexcept {
+    if (this != &other) {
+        server_ = std::move(other.server_);
+        source_id_ = std::move(other.source_id_);
+
+        std::lock_guard<std::mutex> lock(other.metrics_mutex_);
+        custom_metrics_ = std::move(other.custom_metrics_);
+    }
+    return *this;
+}
+
+// ============================================================================
+// IMonitor interface implementation
+// ============================================================================
+
+common::VoidResult file_transfer_monitor_adapter::record_metric(
+    const std::string& name, double value) {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    custom_metrics_[name] = custom_metric{
+        value,
+        common::interfaces::metric_type::gauge,
+        {}
+    };
+    return common::ok();
+}
+
+common::VoidResult file_transfer_monitor_adapter::record_metric(
+    const std::string& name,
+    double value,
+    const std::unordered_map<std::string, std::string>& tags) {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    custom_metrics_[name] = custom_metric{
+        value,
+        common::interfaces::metric_type::gauge,
+        tags
+    };
+    return common::ok();
+}
+
+common::Result<common::interfaces::metrics_snapshot> file_transfer_monitor_adapter::get_metrics() {
+    return collect_server_metrics();
+}
+
+common::Result<common::interfaces::health_check_result> file_transfer_monitor_adapter::check_health() {
+    return check_server_health();
+}
+
+common::VoidResult file_transfer_monitor_adapter::reset() {
+    std::lock_guard<std::mutex> lock(metrics_mutex_);
+    custom_metrics_.clear();
+    return common::ok();
+}
+
+// ============================================================================
+// Additional methods
+// ============================================================================
+
+std::string file_transfer_monitor_adapter::get_source_id() const {
+    return source_id_;
+}
+
+bool file_transfer_monitor_adapter::is_server_available() const {
+    return !server_.expired();
+}
+
+// ============================================================================
+// Private helper methods
+// ============================================================================
+
+common::interfaces::metrics_snapshot file_transfer_monitor_adapter::collect_server_metrics() const {
+    common::interfaces::metrics_snapshot snapshot;
+    snapshot.source_id = source_id_;
+    snapshot.capture_time = std::chrono::system_clock::now();
+
+    auto server = server_.lock();
+    if (!server) {
+        // Return empty snapshot if server is not available
+        return snapshot;
+    }
+
+    // Get server statistics
+    auto stats = server->get_statistics();
+
+    // Transfer metrics (counters)
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_sent",
+        static_cast<double>(stats.total_bytes_sent),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.bytes_received",
+        static_cast<double>(stats.total_bytes_received),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.completed_uploads",
+        static_cast<double>(stats.total_files_uploaded),
+        common::interfaces::metric_type::counter);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.completed_downloads",
+        static_cast<double>(stats.total_files_downloaded),
+        common::interfaces::metric_type::counter);
+
+    // Active transfer metrics (gauges)
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_transfers",
+        static_cast<double>(stats.active_transfers),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_uploads",
+        static_cast<double>(stats.active_uploads),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_downloads",
+        static_cast<double>(stats.active_downloads),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.active_connections",
+        static_cast<double>(stats.active_connections),
+        common::interfaces::metric_type::gauge);
+
+    // Uptime metric (counter)
+    snapshot.metrics.emplace_back(
+        "file_transfer.uptime_ms",
+        static_cast<double>(stats.uptime.count()),
+        common::interfaces::metric_type::counter);
+
+    // Quota metrics
+    auto quota_usage = server->get_quota_usage();
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.quota_usage_percent",
+        quota_usage.usage_percent,
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.quota_used_bytes",
+        static_cast<double>(quota_usage.used_bytes),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.quota_available_bytes",
+        static_cast<double>(quota_usage.available_bytes),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.quota_total_bytes",
+        static_cast<double>(quota_usage.total_quota),
+        common::interfaces::metric_type::gauge);
+
+    snapshot.metrics.emplace_back(
+        "file_transfer.file_count",
+        static_cast<double>(quota_usage.file_count),
+        common::interfaces::metric_type::gauge);
+
+    // Add custom metrics
+    {
+        std::lock_guard<std::mutex> lock(metrics_mutex_);
+        for (const auto& [name, metric] : custom_metrics_) {
+            common::interfaces::metric_value mv(name, metric.value, metric.type);
+            mv.tags = metric.tags;
+            snapshot.metrics.push_back(std::move(mv));
+        }
+    }
+
+    return snapshot;
+}
+
+common::interfaces::health_check_result file_transfer_monitor_adapter::check_server_health() const {
+    common::interfaces::health_check_result result;
+    result.timestamp = std::chrono::system_clock::now();
+
+    auto start_time = std::chrono::steady_clock::now();
+
+    auto server = server_.lock();
+    if (!server) {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Server reference is not available";
+        result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start_time);
+        return result;
+    }
+
+    // Check 1: Server running status
+    if (!server->is_running()) {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Server is not running";
+        result.metadata["server_state"] = to_string(server->state());
+        result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            std::chrono::steady_clock::now() - start_time);
+        return result;
+    }
+
+    // Initialize as healthy
+    result.status = common::interfaces::health_status::healthy;
+    result.message = "Server is healthy";
+
+    // Check 2: Quota status
+    auto quota_usage = server->get_quota_usage();
+    result.metadata["quota_usage_percent"] = std::to_string(quota_usage.usage_percent);
+
+    if (quota_usage.usage_percent > 95.0) {
+        result.status = common::interfaces::health_status::unhealthy;
+        result.message = "Storage quota critical (>95%)";
+    } else if (quota_usage.usage_percent > 80.0) {
+        if (result.status == common::interfaces::health_status::healthy) {
+            result.status = common::interfaces::health_status::degraded;
+            result.message = "Storage quota warning (>80%)";
+        }
+    }
+
+    // Check 3: Connection capacity
+    auto stats = server->get_statistics();
+    const auto& config = server->config();
+    double connection_usage = config.max_connections > 0
+        ? static_cast<double>(stats.active_connections) / static_cast<double>(config.max_connections) * 100.0
+        : 0.0;
+
+    result.metadata["connection_usage_percent"] = std::to_string(connection_usage);
+    result.metadata["active_connections"] = std::to_string(stats.active_connections);
+    result.metadata["max_connections"] = std::to_string(config.max_connections);
+
+    if (connection_usage >= 90.0) {
+        if (result.status == common::interfaces::health_status::healthy) {
+            result.status = common::interfaces::health_status::degraded;
+            result.message = "Near connection limit (>=90%)";
+        }
+    }
+
+    // Add additional metadata
+    result.metadata["server_state"] = to_string(server->state());
+    result.metadata["uptime_ms"] = std::to_string(stats.uptime.count());
+    result.metadata["active_transfers"] = std::to_string(stats.active_transfers);
+
+    result.check_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::steady_clock::now() - start_time);
+
+    return result;
+}
+
+#endif  // KCENON_WITH_COMMON_SYSTEM
+
+}  // namespace kcenon::file_transfer::adapters


### PR DESCRIPTION
## Summary

Implements monitoring system integration for the file_trans_system library, enabling server and client components to be observed through standardized common_system interfaces.

### New Adapters

- **`file_transfer_monitor_adapter`** - IMonitor implementation for server metrics
  - Collects transfer metrics (bytes sent/received, active transfers)
  - Tracks quota usage and connection statistics
  - Supports custom metric recording with tags

- **`file_transfer_server_monitorable`** - IMonitorable for server observability
  - Provides health checks with quota/connection status
  - Reports metrics including uptime, active connections, file counts

- **`file_transfer_client_monitorable`** - IMonitorable for client observability
  - Tracks upload/download statistics and error counts
  - Reports connection health and active transfer status

### Features

- Graceful degradation when common_system is unavailable via `KCENON_WITH_COMMON_SYSTEM` flag
- Weak pointer references to prevent circular dependencies
- Thread-safe metric collection
- Comprehensive health check with multi-level status (healthy, degraded, unhealthy)

### Additional Fixes

- Fixed build errors in cloud example files (unique_ptr to shared_ptr conversion)

## Test Plan

- [x] Project builds successfully
- [x] Unit tests pass (62/62)
- [x] Adapters compile conditionally based on feature flag

## Related Issues

Closes #164