### PR TITLE
feat(adapters): add thread pool adapter for file transfer operations

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -269,6 +269,7 @@ set(FILE_TRANS_SOURCES
     src/adapters/logger_adapter.cpp
     src/adapters/monitoring_adapter.cpp
     src/adapters/monitorable_adapter.cpp
+    src/adapters/thread_pool_adapter.cpp
     src/server/file_transfer_server.cpp
     src/server/server_pipeline.cpp
     src/server/pipeline_jobs.cpp

--- a/include/kcenon/file_transfer/adapters/thread_pool_adapter.h
+++ b/include/kcenon/file_transfer/adapters/thread_pool_adapter.h
@@ -1,0 +1,342 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, kcenon
+// All rights reserved.
+
+/**
+ * @file thread_pool_adapter.h
+ * @brief Thread pool adapter for file_trans_system
+ *
+ * This adapter provides a unified thread pool interface for file transfer operations,
+ * supporting both thread_system integration and standalone fallback modes.
+ *
+ * Features:
+ * - Stage-based task tracking for pipeline monitoring
+ * - Delayed task scheduling for retry operations
+ * - Seamless integration with thread_system when available
+ * - Fallback to std::async when thread_system is unavailable
+ *
+ * @since 0.3.0
+ */
+
+#pragma once
+
+#include <atomic>
+#include <chrono>
+#include <functional>
+#include <future>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+
+#include "../config/feature_flags.h"
+
+#if KCENON_WITH_NETWORK_SYSTEM
+#include <kcenon/network/integration/thread_integration.h>
+#endif
+
+#if KCENON_WITH_THREAD_SYSTEM
+#include <kcenon/thread/core/thread_pool.h>
+#endif
+
+namespace kcenon::file_transfer::adapters {
+
+/**
+ * @brief Interface for thread pool operations in file_trans_system
+ *
+ * This abstraction allows:
+ * - Use of thread_system's thread_pool when available
+ * - Fallback to basic_thread_pool from network_system or std::async
+ * - Delayed task scheduling for retry operations
+ * - Stage-based task tracking for pipeline monitoring
+ */
+class transfer_thread_pool_interface {
+public:
+    virtual ~transfer_thread_pool_interface() = default;
+
+    /**
+     * @brief Submit a task for execution
+     * @param task The task to execute
+     * @return Future for the task completion
+     */
+    virtual std::future<void> submit(std::function<void()> task) = 0;
+
+    /**
+     * @brief Submit a task with delay (useful for retries with backoff)
+     * @param task The task to execute
+     * @param delay Time to wait before executing the task
+     * @return Future for the task completion
+     */
+    virtual std::future<void> submit_delayed(
+        std::function<void()> task,
+        std::chrono::milliseconds delay) = 0;
+
+    /**
+     * @brief Submit a task to a specific pipeline stage for tracking
+     * @param task The task to execute
+     * @param stage_name Name of the pipeline stage (e.g., "chunk_processing")
+     * @return Future for the task completion
+     *
+     * @note Stage names are used for metrics collection and debugging.
+     *       The actual execution is the same as submit(), but task counts
+     *       are tracked per stage.
+     */
+    virtual std::future<void> submit_to_stage(
+        std::function<void()> task,
+        const std::string& stage_name) = 0;
+
+    /**
+     * @brief Get the number of worker threads
+     * @return Worker thread count
+     */
+    [[nodiscard]] virtual size_t worker_count() const = 0;
+
+    /**
+     * @brief Check if the pool is running
+     * @return true if the pool is active
+     */
+    [[nodiscard]] virtual bool is_running() const = 0;
+
+    /**
+     * @brief Get total pending task count
+     * @return Number of tasks waiting to be executed
+     */
+    [[nodiscard]] virtual size_t pending_tasks() const = 0;
+
+    /**
+     * @brief Get pending task count for a specific stage
+     * @param stage_name Name of the pipeline stage
+     * @return Number of tasks waiting for that stage
+     */
+    [[nodiscard]] virtual size_t pending_tasks(const std::string& stage_name) const = 0;
+};
+
+#if KCENON_WITH_THREAD_SYSTEM
+
+/**
+ * @brief Adapter that wraps thread_system::thread_pool for file transfers
+ *
+ * This adapter provides:
+ * - Direct integration with thread_system's thread_pool
+ * - Stage-based task tracking for pipeline monitoring
+ * - Delayed task scheduling via thread_pool's native support
+ *
+ * @note Thread-safe: All public methods are safe to call from multiple threads.
+ */
+class thread_system_transfer_adapter : public transfer_thread_pool_interface {
+public:
+    /**
+     * @brief Construct with an existing thread_pool
+     * @param pool Shared pointer to thread_system's thread_pool
+     * @param pool_name Name for identification in logs and metrics
+     * @param worker_count Number of workers in the pool (for reporting)
+     */
+    explicit thread_system_transfer_adapter(
+        std::shared_ptr<kcenon::thread::thread_pool> pool,
+        const std::string& pool_name = "file_transfer_pool",
+        size_t worker_count = 0);
+
+    /**
+     * @brief Destructor
+     */
+    ~thread_system_transfer_adapter() override;
+
+    // Non-copyable
+    thread_system_transfer_adapter(const thread_system_transfer_adapter&) = delete;
+    thread_system_transfer_adapter& operator=(const thread_system_transfer_adapter&) = delete;
+
+    // Movable
+    thread_system_transfer_adapter(thread_system_transfer_adapter&&) noexcept;
+    thread_system_transfer_adapter& operator=(thread_system_transfer_adapter&&) noexcept;
+
+    /**
+     * @brief Factory method to create a default adapter
+     * @param worker_count Number of worker threads (0 = auto-detect from hardware)
+     * @param pool_name Name for identification
+     * @return Shared pointer to the adapter
+     */
+    [[nodiscard]] static std::shared_ptr<thread_system_transfer_adapter> create_default(
+        size_t worker_count = 0,
+        const std::string& pool_name = "file_transfer_pool");
+
+    // transfer_thread_pool_interface implementation
+    std::future<void> submit(std::function<void()> task) override;
+    std::future<void> submit_delayed(
+        std::function<void()> task,
+        std::chrono::milliseconds delay) override;
+    std::future<void> submit_to_stage(
+        std::function<void()> task,
+        const std::string& stage_name) override;
+
+    [[nodiscard]] size_t worker_count() const override;
+    [[nodiscard]] bool is_running() const override;
+    [[nodiscard]] size_t pending_tasks() const override;
+    [[nodiscard]] size_t pending_tasks(const std::string& stage_name) const override;
+
+    /**
+     * @brief Get the underlying thread_pool
+     * @return Shared pointer to the underlying pool
+     */
+    [[nodiscard]] std::shared_ptr<kcenon::thread::thread_pool> underlying_pool() const;
+
+    /**
+     * @brief Get the pool name
+     * @return Pool name string
+     */
+    [[nodiscard]] std::string pool_name() const;
+
+private:
+    struct impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+#endif  // KCENON_WITH_THREAD_SYSTEM
+
+#if KCENON_WITH_NETWORK_SYSTEM
+
+/**
+ * @brief Adapter that wraps network_system's thread_pool_interface
+ *
+ * This adapter bridges network_system's thread pool abstraction to
+ * file_transfer's transfer_thread_pool_interface, adding stage tracking.
+ *
+ * @note Use this when you want to share a thread pool with network_system,
+ *       or when thread_system is not available but network_system is.
+ */
+class network_pool_transfer_adapter : public transfer_thread_pool_interface {
+public:
+    /**
+     * @brief Construct with a network_system thread_pool_interface
+     * @param pool Shared pointer to network_system's thread pool
+     * @param pool_name Name for identification
+     */
+    explicit network_pool_transfer_adapter(
+        std::shared_ptr<kcenon::network::integration::thread_pool_interface> pool,
+        const std::string& pool_name = "file_transfer_pool");
+
+    ~network_pool_transfer_adapter() override;
+
+    // Non-copyable
+    network_pool_transfer_adapter(const network_pool_transfer_adapter&) = delete;
+    network_pool_transfer_adapter& operator=(const network_pool_transfer_adapter&) = delete;
+
+    // Movable
+    network_pool_transfer_adapter(network_pool_transfer_adapter&&) noexcept;
+    network_pool_transfer_adapter& operator=(network_pool_transfer_adapter&&) noexcept;
+
+    /**
+     * @brief Factory method using network_system's basic_thread_pool
+     * @param worker_count Number of worker threads (0 = auto-detect)
+     * @param pool_name Name for identification
+     * @return Shared pointer to the adapter
+     */
+    [[nodiscard]] static std::shared_ptr<network_pool_transfer_adapter> create_basic(
+        size_t worker_count = 0,
+        const std::string& pool_name = "file_transfer_pool");
+
+    // transfer_thread_pool_interface implementation
+    std::future<void> submit(std::function<void()> task) override;
+    std::future<void> submit_delayed(
+        std::function<void()> task,
+        std::chrono::milliseconds delay) override;
+    std::future<void> submit_to_stage(
+        std::function<void()> task,
+        const std::string& stage_name) override;
+
+    [[nodiscard]] size_t worker_count() const override;
+    [[nodiscard]] bool is_running() const override;
+    [[nodiscard]] size_t pending_tasks() const override;
+    [[nodiscard]] size_t pending_tasks(const std::string& stage_name) const override;
+
+private:
+    struct impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+#endif  // KCENON_WITH_NETWORK_SYSTEM
+
+/**
+ * @brief Fallback implementation using std::async
+ *
+ * This implementation is used when neither thread_system nor network_system
+ * thread pools are available. It uses std::async for task execution.
+ *
+ * @note This fallback has limited functionality:
+ *       - No delayed execution (returns immediately completed future with delay)
+ *       - worker_count() returns hardware_concurrency
+ *       - pending_tasks() is always 0 (no queue)
+ */
+class async_transfer_pool : public transfer_thread_pool_interface {
+public:
+    async_transfer_pool();
+    ~async_transfer_pool() override;
+
+    // Non-copyable, non-movable (stateless singleton-like)
+    async_transfer_pool(const async_transfer_pool&) = delete;
+    async_transfer_pool& operator=(const async_transfer_pool&) = delete;
+
+    std::future<void> submit(std::function<void()> task) override;
+    std::future<void> submit_delayed(
+        std::function<void()> task,
+        std::chrono::milliseconds delay) override;
+    std::future<void> submit_to_stage(
+        std::function<void()> task,
+        const std::string& stage_name) override;
+
+    [[nodiscard]] size_t worker_count() const override;
+    [[nodiscard]] bool is_running() const override;
+    [[nodiscard]] size_t pending_tasks() const override;
+    [[nodiscard]] size_t pending_tasks(const std::string& stage_name) const override;
+
+private:
+    struct impl;
+    std::unique_ptr<impl> pimpl_;
+};
+
+/**
+ * @brief Factory for creating appropriate thread pool adapter
+ *
+ * This factory automatically selects the best available implementation:
+ * 1. thread_system_transfer_adapter (when KCENON_WITH_THREAD_SYSTEM)
+ * 2. network_pool_transfer_adapter (when KCENON_WITH_NETWORK_SYSTEM only)
+ * 3. async_transfer_pool (fallback)
+ */
+class transfer_pool_factory {
+public:
+    /**
+     * @brief Create the best available thread pool adapter
+     * @param worker_count Number of worker threads (0 = auto-detect)
+     * @param pool_name Name for identification
+     * @return Shared pointer to the adapter
+     */
+    [[nodiscard]] static std::shared_ptr<transfer_thread_pool_interface> create(
+        size_t worker_count = 0,
+        const std::string& pool_name = "file_transfer_pool");
+
+    /**
+     * @brief Check if thread_system is available
+     * @return true if thread_system can be used
+     */
+    [[nodiscard]] static constexpr bool has_thread_system() noexcept {
+#if KCENON_WITH_THREAD_SYSTEM
+        return true;
+#else
+        return false;
+#endif
+    }
+
+    /**
+     * @brief Check if network_system thread pool is available
+     * @return true if network_system thread pool can be used
+     */
+    [[nodiscard]] static constexpr bool has_network_pool() noexcept {
+#if KCENON_WITH_NETWORK_SYSTEM
+        return true;
+#else
+        return false;
+#endif
+    }
+};
+
+}  // namespace kcenon::file_transfer::adapters

--- a/include/kcenon/file_transfer/file_transfer.h
+++ b/include/kcenon/file_transfer/file_transfer.h
@@ -43,6 +43,7 @@
 #include "kcenon/file_transfer/adapters/logger_adapter.h"
 #include "kcenon/file_transfer/adapters/monitoring_adapter.h"
 #include "kcenon/file_transfer/adapters/monitorable_adapter.h"
+#include "kcenon/file_transfer/adapters/thread_pool_adapter.h"
 
 namespace kcenon::file_transfer {
 

--- a/src/adapters/thread_pool_adapter.cpp
+++ b/src/adapters/thread_pool_adapter.cpp
@@ -1,0 +1,439 @@
+// BSD 3-Clause License
+//
+// Copyright (c) 2025, kcenon
+// All rights reserved.
+
+/**
+ * @file thread_pool_adapter.cpp
+ * @brief Thread pool adapter implementation for file_trans_system
+ */
+
+#include "kcenon/file_transfer/adapters/thread_pool_adapter.h"
+
+#include <thread>
+
+#if KCENON_WITH_THREAD_SYSTEM
+// Suppress deprecation warnings from thread_system headers
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#include <kcenon/thread/core/job.h>
+#include <kcenon/thread/core/job_queue.h>
+#include <kcenon/thread/core/thread_worker.h>
+#pragma clang diagnostic pop
+#endif
+
+namespace kcenon::file_transfer::adapters {
+
+// ============================================================================
+// Stage tracking helper (shared implementation)
+// ============================================================================
+
+namespace {
+
+class stage_tracker {
+public:
+    void increment(const std::string& stage_name) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = counts_.find(stage_name);
+        if (it == counts_.end()) {
+            counts_.emplace(stage_name, 1);
+        } else {
+            it->second.fetch_add(1, std::memory_order_relaxed);
+        }
+    }
+
+    void decrement(const std::string& stage_name) {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = counts_.find(stage_name);
+        if (it != counts_.end()) {
+            auto current = it->second.load();
+            if (current > 0) {
+                it->second.fetch_sub(1, std::memory_order_relaxed);
+            }
+        }
+    }
+
+    [[nodiscard]] size_t count(const std::string& stage_name) const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        auto it = counts_.find(stage_name);
+        if (it != counts_.end()) {
+            return it->second.load();
+        }
+        return 0;
+    }
+
+private:
+    mutable std::mutex mutex_;
+    std::unordered_map<std::string, std::atomic<size_t>> counts_;
+};
+
+}  // namespace
+
+// ============================================================================
+// thread_system_transfer_adapter implementation
+// ============================================================================
+
+#if KCENON_WITH_THREAD_SYSTEM
+
+/**
+ * @brief Simple job that wraps a function for thread_system execution
+ */
+class function_job : public kcenon::thread::job {
+public:
+    explicit function_job(std::function<void()> func, const std::string& name = "function_job")
+        : job(name), func_(std::move(func)) {}
+
+    [[nodiscard]] auto do_work() -> common::VoidResult override {
+        if (func_) {
+            func_();
+        }
+        return common::ok();
+    }
+
+private:
+    std::function<void()> func_;
+};
+
+// Implementation struct for thread_system_transfer_adapter (PIMPL for mutex)
+struct thread_system_transfer_adapter::impl {
+    std::shared_ptr<kcenon::thread::thread_pool> pool;
+    std::string pool_name;
+    size_t worker_count{0};
+    stage_tracker tracker;
+};
+
+thread_system_transfer_adapter::thread_system_transfer_adapter(
+    std::shared_ptr<kcenon::thread::thread_pool> pool,
+    const std::string& pool_name,
+    size_t worker_count)
+    : pimpl_(std::make_unique<impl>()) {
+    pimpl_->pool = std::move(pool);
+    pimpl_->pool_name = pool_name;
+    pimpl_->worker_count = worker_count;
+}
+
+thread_system_transfer_adapter::~thread_system_transfer_adapter() = default;
+
+thread_system_transfer_adapter::thread_system_transfer_adapter(
+    thread_system_transfer_adapter&&) noexcept = default;
+
+thread_system_transfer_adapter& thread_system_transfer_adapter::operator=(
+    thread_system_transfer_adapter&&) noexcept = default;
+
+std::shared_ptr<thread_system_transfer_adapter>
+thread_system_transfer_adapter::create_default(size_t worker_count,
+                                                const std::string& pool_name) {
+    if (worker_count == 0) {
+        worker_count = std::thread::hardware_concurrency();
+        if (worker_count == 0) {
+            worker_count = 4;
+        }
+    }
+
+    auto pool = std::make_shared<kcenon::thread::thread_pool>(pool_name);
+
+    // Add workers to the pool
+    for (size_t i = 0; i < worker_count; ++i) {
+        auto worker = std::make_unique<kcenon::thread::thread_worker>();
+        worker->set_job_queue(pool->get_job_queue());
+        pool->enqueue(std::move(worker));
+    }
+
+    // Start the pool
+    pool->start();
+
+    return std::make_shared<thread_system_transfer_adapter>(std::move(pool), pool_name, worker_count);
+}
+
+std::future<void> thread_system_transfer_adapter::submit(
+    std::function<void()> task) {
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+
+    auto wrapped_task = [task = std::move(task), promise]() {
+        try {
+            task();
+            promise->set_value();
+        } catch (...) {
+            promise->set_exception(std::current_exception());
+        }
+    };
+
+    auto job = std::make_unique<function_job>(std::move(wrapped_task), "transfer_task");
+    pimpl_->pool->enqueue(std::move(job));
+
+    return future;
+}
+
+std::future<void> thread_system_transfer_adapter::submit_delayed(
+    std::function<void()> task, std::chrono::milliseconds delay) {
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+
+    // Create a task that sleeps then executes
+    auto delayed_task = [task = std::move(task), promise, delay]() {
+        std::this_thread::sleep_for(delay);
+        try {
+            task();
+            promise->set_value();
+        } catch (...) {
+            promise->set_exception(std::current_exception());
+        }
+    };
+
+    auto job = std::make_unique<function_job>(std::move(delayed_task), "delayed_transfer_task");
+    pimpl_->pool->enqueue(std::move(job));
+
+    return future;
+}
+
+std::future<void> thread_system_transfer_adapter::submit_to_stage(
+    std::function<void()> task, const std::string& stage_name) {
+    pimpl_->tracker.increment(stage_name);
+
+    auto promise = std::make_shared<std::promise<void>>();
+    auto future = promise->get_future();
+
+    // Capture pimpl_ for stage tracking (raw pointer is safe - adapter outlives tasks)
+    auto* tracker = &pimpl_->tracker;
+    auto wrapped_task = [task = std::move(task), promise, tracker,
+                         stage = stage_name]() {
+        try {
+            task();
+            promise->set_value();
+        } catch (...) {
+            promise->set_exception(std::current_exception());
+        }
+        tracker->decrement(stage);
+    };
+
+    auto job = std::make_unique<function_job>(std::move(wrapped_task), "staged_transfer_task");
+    pimpl_->pool->enqueue(std::move(job));
+
+    return future;
+}
+
+size_t thread_system_transfer_adapter::worker_count() const {
+    return pimpl_->worker_count;
+}
+
+bool thread_system_transfer_adapter::is_running() const {
+    return pimpl_->pool != nullptr;
+}
+
+size_t thread_system_transfer_adapter::pending_tasks() const {
+    if (pimpl_->pool) {
+        auto queue = pimpl_->pool->get_job_queue();
+        return queue ? queue->size() : 0;
+    }
+    return 0;
+}
+
+size_t thread_system_transfer_adapter::pending_tasks(
+    const std::string& stage_name) const {
+    return pimpl_->tracker.count(stage_name);
+}
+
+std::shared_ptr<kcenon::thread::thread_pool>
+thread_system_transfer_adapter::underlying_pool() const {
+    return pimpl_->pool;
+}
+
+std::string thread_system_transfer_adapter::pool_name() const {
+    return pimpl_->pool_name;
+}
+
+#endif  // KCENON_WITH_THREAD_SYSTEM
+
+// ============================================================================
+// network_pool_transfer_adapter implementation
+// ============================================================================
+
+#if KCENON_WITH_NETWORK_SYSTEM
+
+// Implementation struct for network_pool_transfer_adapter (PIMPL for mutex)
+struct network_pool_transfer_adapter::impl {
+    std::shared_ptr<kcenon::network::integration::thread_pool_interface> pool;
+    std::string pool_name;
+    stage_tracker tracker;
+};
+
+network_pool_transfer_adapter::network_pool_transfer_adapter(
+    std::shared_ptr<kcenon::network::integration::thread_pool_interface> pool,
+    const std::string& pool_name)
+    : pimpl_(std::make_unique<impl>()) {
+    pimpl_->pool = std::move(pool);
+    pimpl_->pool_name = pool_name;
+}
+
+network_pool_transfer_adapter::~network_pool_transfer_adapter() = default;
+
+network_pool_transfer_adapter::network_pool_transfer_adapter(
+    network_pool_transfer_adapter&&) noexcept = default;
+
+network_pool_transfer_adapter& network_pool_transfer_adapter::operator=(
+    network_pool_transfer_adapter&&) noexcept = default;
+
+std::shared_ptr<network_pool_transfer_adapter>
+network_pool_transfer_adapter::create_basic(size_t worker_count,
+                                             const std::string& pool_name) {
+    auto pool =
+        std::make_shared<kcenon::network::integration::basic_thread_pool>(
+            worker_count);
+    return std::make_shared<network_pool_transfer_adapter>(std::move(pool),
+                                                            pool_name);
+}
+
+std::future<void> network_pool_transfer_adapter::submit(
+    std::function<void()> task) {
+    return pimpl_->pool->submit(std::move(task));
+}
+
+std::future<void> network_pool_transfer_adapter::submit_delayed(
+    std::function<void()> task, std::chrono::milliseconds delay) {
+    return pimpl_->pool->submit_delayed(std::move(task), delay);
+}
+
+std::future<void> network_pool_transfer_adapter::submit_to_stage(
+    std::function<void()> task, const std::string& stage_name) {
+    pimpl_->tracker.increment(stage_name);
+
+    // Capture pimpl_ for stage tracking
+    auto* tracker = &pimpl_->tracker;
+    auto wrapped_task = [task = std::move(task), tracker, stage = stage_name]() {
+        try {
+            task();
+        } catch (...) {
+            tracker->decrement(stage);
+            throw;
+        }
+        tracker->decrement(stage);
+    };
+
+    return pimpl_->pool->submit(std::move(wrapped_task));
+}
+
+size_t network_pool_transfer_adapter::worker_count() const {
+    return pimpl_->pool ? pimpl_->pool->worker_count() : 0;
+}
+
+bool network_pool_transfer_adapter::is_running() const {
+    return pimpl_->pool ? pimpl_->pool->is_running() : false;
+}
+
+size_t network_pool_transfer_adapter::pending_tasks() const {
+    return pimpl_->pool ? pimpl_->pool->pending_tasks() : 0;
+}
+
+size_t network_pool_transfer_adapter::pending_tasks(
+    const std::string& stage_name) const {
+    return pimpl_->tracker.count(stage_name);
+}
+
+#endif  // KCENON_WITH_NETWORK_SYSTEM
+
+// ============================================================================
+// async_transfer_pool implementation
+// ============================================================================
+
+// Implementation struct for async_transfer_pool (PIMPL for mutex)
+struct async_transfer_pool::impl {
+    std::atomic<size_t> active_tasks{0};
+    stage_tracker tracker;
+};
+
+async_transfer_pool::async_transfer_pool()
+    : pimpl_(std::make_unique<impl>()) {}
+
+async_transfer_pool::~async_transfer_pool() = default;
+
+std::future<void> async_transfer_pool::submit(std::function<void()> task) {
+    pimpl_->active_tasks.fetch_add(1, std::memory_order_relaxed);
+
+    auto* pimpl = pimpl_.get();
+    return std::async(std::launch::async,
+                      [pimpl, task = std::move(task)]() {
+                          try {
+                              task();
+                          } catch (...) {
+                              pimpl->active_tasks.fetch_sub(1, std::memory_order_relaxed);
+                              throw;
+                          }
+                          pimpl->active_tasks.fetch_sub(1, std::memory_order_relaxed);
+                      });
+}
+
+std::future<void> async_transfer_pool::submit_delayed(
+    std::function<void()> task, std::chrono::milliseconds delay) {
+    pimpl_->active_tasks.fetch_add(1, std::memory_order_relaxed);
+
+    auto* pimpl = pimpl_.get();
+    return std::async(std::launch::async,
+                      [pimpl, task = std::move(task), delay]() {
+                          std::this_thread::sleep_for(delay);
+                          try {
+                              task();
+                          } catch (...) {
+                              pimpl->active_tasks.fetch_sub(1, std::memory_order_relaxed);
+                              throw;
+                          }
+                          pimpl->active_tasks.fetch_sub(1, std::memory_order_relaxed);
+                      });
+}
+
+std::future<void> async_transfer_pool::submit_to_stage(
+    std::function<void()> task, const std::string& stage_name) {
+    pimpl_->tracker.increment(stage_name);
+    pimpl_->active_tasks.fetch_add(1, std::memory_order_relaxed);
+
+    auto* pimpl = pimpl_.get();
+    return std::async(std::launch::async,
+                      [pimpl, task = std::move(task), stage = stage_name]() {
+                          try {
+                              task();
+                          } catch (...) {
+                              pimpl->active_tasks.fetch_sub(1, std::memory_order_relaxed);
+                              pimpl->tracker.decrement(stage);
+                              throw;
+                          }
+                          pimpl->active_tasks.fetch_sub(1, std::memory_order_relaxed);
+                          pimpl->tracker.decrement(stage);
+                      });
+}
+
+size_t async_transfer_pool::worker_count() const {
+    auto count = std::thread::hardware_concurrency();
+    return count > 0 ? count : 4;
+}
+
+bool async_transfer_pool::is_running() const { return true; }
+
+size_t async_transfer_pool::pending_tasks() const {
+    return pimpl_->active_tasks.load(std::memory_order_relaxed);
+}
+
+size_t async_transfer_pool::pending_tasks(const std::string& stage_name) const {
+    return pimpl_->tracker.count(stage_name);
+}
+
+// ============================================================================
+// transfer_pool_factory implementation
+// ============================================================================
+
+std::shared_ptr<transfer_thread_pool_interface> transfer_pool_factory::create(
+    size_t worker_count, const std::string& pool_name) {
+    // Priority: thread_system > network_system > async fallback
+
+#if KCENON_WITH_THREAD_SYSTEM
+    return thread_system_transfer_adapter::create_default(worker_count,
+                                                           pool_name);
+#elif KCENON_WITH_NETWORK_SYSTEM
+    return network_pool_transfer_adapter::create_basic(worker_count, pool_name);
+#else
+    (void)worker_count;
+    (void)pool_name;
+    return std::make_shared<async_transfer_pool>();
+#endif
+}
+
+}  // namespace kcenon::file_transfer::adapters


### PR DESCRIPTION
## Summary
- Implement `transfer_thread_pool_interface` abstraction for unified thread pool operations
- Add `thread_system_transfer_adapter` for thread_system integration
- Add `network_pool_transfer_adapter` for network_system fallback
- Add `async_transfer_pool` as final fallback using `std::async`
- Include `transfer_pool_factory` for automatic implementation selection

## What
This PR implements Phase 10 of the file_trans_system adapter work, providing a thread pool abstraction layer that:
- Supports stage-based task tracking for pipeline monitoring
- Enables delayed task scheduling for retry operations with backoff
- Uses PIMPL pattern for ABI stability and movability
- Automatically selects the best available implementation based on compile-time feature flags

### Key Components

| Component | Description |
|-----------|-------------|
| `transfer_thread_pool_interface` | Abstract interface for thread pool operations |
| `thread_system_transfer_adapter` | Adapter wrapping `kcenon::thread::thread_pool` |
| `network_pool_transfer_adapter` | Adapter wrapping network_system's `basic_thread_pool` |
| `async_transfer_pool` | Fallback using `std::async` when no thread pools available |
| `transfer_pool_factory` | Factory for creating the best available implementation |

## Why
Closes #165

This abstraction enables file_trans_system to:
- Use thread_system's thread_pool for optimal performance when available
- Gracefully degrade to network_system or std::async when dependencies are missing
- Track tasks by pipeline stage for better monitoring and debugging
- Schedule delayed tasks for retry operations with exponential backoff

## Test Plan
- [x] Build succeeds with thread_system enabled
- [x] Unit tests pass (1030/1031 - 1 unrelated failure in AesGcmEngineTest)
- [x] Manual verification of API surface matches requirements